### PR TITLE
Implement REST API and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository contains a Streamlit application for tracking gym workouts. Ever
 
 - Python 3.9+
 - Streamlit
+- FastAPI
+- Uvicorn
 
 Install dependencies with:
 
@@ -23,3 +25,8 @@ pip install -r requirements.txt
 streamlit run streamlit_app.py
 ```
 
+## Running the REST API
+
+```bash
+uvicorn rest_api:app --reload
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 streamlit
-
+fastapi
+uvicorn
+requests
+httpx

--- a/rest_api.py
+++ b/rest_api.py
@@ -1,0 +1,72 @@
+import datetime
+from fastapi import FastAPI
+from db import WorkoutRepository, ExerciseRepository, SetRepository
+
+
+class GymAPI:
+    """Provides REST endpoints for workout logging."""
+
+    def __init__(self, db_path: str = "workout.db") -> None:
+        self.workouts = WorkoutRepository(db_path)
+        self.exercises = ExerciseRepository(db_path)
+        self.sets = SetRepository(db_path)
+        self.app = FastAPI()
+        self._setup_routes()
+
+    def _setup_routes(self) -> None:
+        @self.app.post("/workouts")
+        def create_workout():
+            workout_id = self.workouts.create(datetime.date.today().isoformat())
+            return {"id": workout_id}
+
+        @self.app.get("/workouts")
+        def list_workouts():
+            workouts = self.workouts.fetch_all_workouts()
+            return [{"id": wid, "date": date} for wid, date in workouts]
+
+        @self.app.post("/workouts/{workout_id}/exercises")
+        def add_exercise(workout_id: int, name: str):
+            ex_id = self.exercises.add(workout_id, name)
+            return {"id": ex_id}
+
+        @self.app.delete("/exercises/{exercise_id}")
+        def delete_exercise(exercise_id: int):
+            self.exercises.remove(exercise_id)
+            return {"status": "deleted"}
+
+        @self.app.get("/workouts/{workout_id}/exercises")
+        def list_exercises(workout_id: int):
+            exercises = self.exercises.fetch_for_workout(workout_id)
+            return [{"id": ex_id, "name": name} for ex_id, name in exercises]
+
+        @self.app.post("/exercises/{exercise_id}/sets")
+        def add_set(exercise_id: int, reps: int, weight: float):
+            set_id = self.sets.add(exercise_id, reps, weight)
+            return {"id": set_id}
+
+        @self.app.put("/sets/{set_id}")
+        def update_set(set_id: int, reps: int, weight: float):
+            self.sets.update(set_id, reps, weight)
+            return {"status": "updated"}
+
+        @self.app.delete("/sets/{set_id}")
+        def delete_set(set_id: int):
+            self.sets.remove(set_id)
+            return {"status": "deleted"}
+
+        @self.app.get("/exercises/{exercise_id}/sets")
+        def list_sets(exercise_id: int):
+            sets = self.sets.fetch_for_exercise(exercise_id)
+            return [
+                {"id": sid, "reps": reps, "weight": weight}
+                for sid, reps, weight in sets
+            ]
+
+
+api = GymAPI()
+app = api.app
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,79 @@
+import os
+import datetime
+import unittest
+from fastapi.testclient import TestClient
+from rest_api import GymAPI
+
+
+class APITestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db_path = "test_workout.db"
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        self.api = GymAPI(db_path=self.db_path)
+        self.client = TestClient(self.api.app)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_full_workflow(self) -> None:
+        today = datetime.date.today().isoformat()
+
+        response = self.client.post("/workouts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": 1})
+
+        response = self.client.get("/workouts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [{"id": 1, "date": today}])
+
+        response = self.client.post(
+            "/workouts/1/exercises", params={"name": "Bench Press"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": 1})
+
+        response = self.client.get("/workouts/1/exercises")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [{"id": 1, "name": "Bench Press"}])
+
+        response = self.client.post(
+            "/exercises/1/sets", params={"reps": 10, "weight": 100.0}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": 1})
+
+        response = self.client.get("/exercises/1/sets")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(), [{"id": 1, "reps": 10, "weight": 100.0}]
+        )
+
+        response = self.client.put(
+            "/sets/1", params={"reps": 12, "weight": 105.0}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "updated"})
+
+        response = self.client.get("/exercises/1/sets")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(), [{"id": 1, "reps": 12, "weight": 105.0}]
+        )
+
+        response = self.client.delete("/sets/1")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "deleted"})
+
+        response = self.client.get("/exercises/1/sets")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+        response = self.client.delete("/exercises/1")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "deleted"})
+
+        response = self.client.get("/workouts/1/exercises")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])


### PR DESCRIPTION
## Summary
- add FastAPI-based REST API to expose workout management features
- document REST API usage in README
- list new API dependencies in requirements
- create integration tests using REST API endpoints

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -p 'test*.py' -v`

------
https://chatgpt.com/codex/tasks/task_e_6874a3dfa7c88327a19ea4c948f53565