### PR TITLE
Add RPE field to sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a Streamlit application for tracking gym workouts. Ever
 - Create new workouts with the current date.
 - Add and remove exercises for a workout.
 - Add, edit, and delete sets for each exercise.
+- Record the RPE (0-10) for each set.
 
 ## Requirements
 

--- a/db.py
+++ b/db.py
@@ -42,6 +42,7 @@ class Database:
                     exercise_id INTEGER NOT NULL,
                     reps INTEGER NOT NULL,
                     weight REAL NOT NULL,
+                    rpe INTEGER NOT NULL,
                     FOREIGN KEY(exercise_id) REFERENCES exercises(id) ON DELETE CASCADE
                 );"""
             )
@@ -95,24 +96,24 @@ class ExerciseRepository(BaseRepository):
 class SetRepository(BaseRepository):
     """Repository for sets table operations."""
 
-    def add(self, exercise_id: int, reps: int, weight: float) -> int:
+    def add(self, exercise_id: int, reps: int, weight: float, rpe: int) -> int:
         return self.execute(
-            "INSERT INTO sets (exercise_id, reps, weight) VALUES (?, ?, ?);",
-            (exercise_id, reps, weight),
+            "INSERT INTO sets (exercise_id, reps, weight, rpe) VALUES (?, ?, ?, ?);",
+            (exercise_id, reps, weight, rpe),
         )
 
-    def update(self, set_id: int, reps: int, weight: float) -> None:
+    def update(self, set_id: int, reps: int, weight: float, rpe: int) -> None:
         self.execute(
-            "UPDATE sets SET reps = ?, weight = ? WHERE id = ?;",
-            (reps, weight, set_id),
+            "UPDATE sets SET reps = ?, weight = ?, rpe = ? WHERE id = ?;",
+            (reps, weight, rpe, set_id),
         )
 
     def remove(self, set_id: int) -> None:
         self.execute("DELETE FROM sets WHERE id = ?;", (set_id,))
 
-    def fetch_for_exercise(self, exercise_id: int) -> List[Tuple[int, int, float]]:
+    def fetch_for_exercise(self, exercise_id: int) -> List[Tuple[int, int, float, int]]:
         return self.fetch_all(
-            "SELECT id, reps, weight FROM sets WHERE exercise_id = ?;",
+            "SELECT id, reps, weight, rpe FROM sets WHERE exercise_id = ?;",
             (exercise_id,),
         )
 

--- a/rest_api.py
+++ b/rest_api.py
@@ -40,13 +40,13 @@ class GymAPI:
             return [{"id": ex_id, "name": name} for ex_id, name in exercises]
 
         @self.app.post("/exercises/{exercise_id}/sets")
-        def add_set(exercise_id: int, reps: int, weight: float):
-            set_id = self.sets.add(exercise_id, reps, weight)
+        def add_set(exercise_id: int, reps: int, weight: float, rpe: int):
+            set_id = self.sets.add(exercise_id, reps, weight, rpe)
             return {"id": set_id}
 
         @self.app.put("/sets/{set_id}")
-        def update_set(set_id: int, reps: int, weight: float):
-            self.sets.update(set_id, reps, weight)
+        def update_set(set_id: int, reps: int, weight: float, rpe: int):
+            self.sets.update(set_id, reps, weight, rpe)
             return {"status": "updated"}
 
         @self.app.delete("/sets/{set_id}")
@@ -58,8 +58,8 @@ class GymAPI:
         def list_sets(exercise_id: int):
             sets = self.sets.fetch_for_exercise(exercise_id)
             return [
-                {"id": sid, "reps": reps, "weight": weight}
-                for sid, reps, weight in sets
+                {"id": sid, "reps": reps, "weight": weight, "rpe": rpe}
+                for sid, reps, weight, rpe in sets
             ]
 
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -56,8 +56,8 @@ class GymApp:
             if st.button("Remove Exercise", key=f"remove_ex_{exercise_id}"):
                 self.exercises.remove(exercise_id)
                 return
-            for set_id, reps, weight in sets:
-                cols = st.columns(4)
+            for set_id, reps, weight, rpe in sets:
+                cols = st.columns(5)
                 with cols[0]:
                     st.write(f"Set {set_id}")
                 reps_val = cols[1].number_input(
@@ -74,11 +74,19 @@ class GymApp:
                     value=float(weight),
                     key=f"weight_{set_id}",
                 )
-                if cols[3].button("Delete", key=f"del_{set_id}"):
+                rpe_val = cols[3].selectbox(
+                    "RPE",
+                    options=list(range(11)),
+                    index=int(rpe),
+                    key=f"rpe_{set_id}",
+                )
+                if cols[4].button("Delete", key=f"del_{set_id}"):
                     self.sets.remove(set_id)
                     continue
-                if cols[3].button("Update", key=f"upd_{set_id}"):
-                    self.sets.update(set_id, int(reps_val), float(weight_val))
+                if cols[4].button("Update", key=f"upd_{set_id}"):
+                    self.sets.update(
+                        set_id, int(reps_val), float(weight_val), int(rpe_val)
+                    )
             self._add_set_form(exercise_id)
 
     def _add_set_form(self, exercise_id: int) -> None:
@@ -94,10 +102,16 @@ class GymApp:
             step=0.5,
             key=f"new_weight_{exercise_id}",
         )
+        rpe = st.selectbox(
+            "RPE",
+            options=list(range(11)),
+            key=f"new_rpe_{exercise_id}",
+        )
         if st.button("Add Set", key=f"add_set_{exercise_id}"):
-            self.sets.add(exercise_id, int(reps), float(weight))
+            self.sets.add(exercise_id, int(reps), float(weight), int(rpe))
             st.session_state.pop(f"new_reps_{exercise_id}", None)
             st.session_state.pop(f"new_weight_{exercise_id}", None)
+            st.session_state.pop(f"new_rpe_{exercise_id}", None)
 
 
 if __name__ == "__main__":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,10 @@
 import os
+import sys
 import datetime
 import unittest
 from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from rest_api import GymAPI
 
 
@@ -39,7 +42,8 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(response.json(), [{"id": 1, "name": "Bench Press"}])
 
         response = self.client.post(
-            "/exercises/1/sets", params={"reps": 10, "weight": 100.0}
+            "/exercises/1/sets",
+            params={"reps": 10, "weight": 100.0, "rpe": 8},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"id": 1})
@@ -47,11 +51,11 @@ class APITestCase(unittest.TestCase):
         response = self.client.get("/exercises/1/sets")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(), [{"id": 1, "reps": 10, "weight": 100.0}]
+            response.json(), [{"id": 1, "reps": 10, "weight": 100.0, "rpe": 8}]
         )
 
         response = self.client.put(
-            "/sets/1", params={"reps": 12, "weight": 105.0}
+            "/sets/1", params={"reps": 12, "weight": 105.0, "rpe": 9}
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"status": "updated"})
@@ -59,7 +63,7 @@ class APITestCase(unittest.TestCase):
         response = self.client.get("/exercises/1/sets")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(), [{"id": 1, "reps": 12, "weight": 105.0}]
+            response.json(), [{"id": 1, "reps": 12, "weight": 105.0, "rpe": 9}]
         )
 
         response = self.client.delete("/sets/1")


### PR DESCRIPTION
## Summary
- support `rpe` column in the database
- expose `rpe` on REST API
- allow entering RPE in the Streamlit UI
- extend tests for RPE operations
- document RPE tracking in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a7c068108327b6f0b40a9e3719c3