### PR TITLE
Add settings deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a Streamlit application for tracking gym workouts. Ever
 - Add and remove exercises for a workout.
 - Add, edit, and delete sets for each exercise.
 - Record the RPE (0-10) for each set.
+- Delete logged and planned workouts through the Settings tab or REST API.
 
 ## Requirements
 
@@ -31,3 +32,12 @@ streamlit run streamlit_app.py
 ```bash
 uvicorn rest_api:app --reload
 ```
+
+### Deletion Endpoints
+
+Use the following endpoints with the parameter `confirmation=Yes, I confirm` to
+remove data:
+
+- `POST /settings/delete_all` – remove all logged and planned workouts
+- `POST /settings/delete_logged` – remove all logged workouts only
+- `POST /settings/delete_planned` – remove all planned workouts only

--- a/db.py
+++ b/db.py
@@ -92,6 +92,9 @@ class BaseRepository(Database):
             cursor.execute(query, params)
             return cursor.fetchall()
 
+    def _delete_all(self, table: str) -> None:
+        self.execute(f"DELETE FROM {table};")
+
 
 class WorkoutRepository(BaseRepository):
     """Repository for workout table operations."""
@@ -101,6 +104,9 @@ class WorkoutRepository(BaseRepository):
 
     def fetch_all_workouts(self) -> List[Tuple[int, str]]:
         return self.fetch_all("SELECT id, date FROM workouts ORDER BY id DESC;")
+
+    def delete_all(self) -> None:
+        self._delete_all("workouts")
 
 
 class ExerciseRepository(BaseRepository):
@@ -203,6 +209,9 @@ class PlannedWorkoutRepository(BaseRepository):
         return super().fetch_all(
             "SELECT id, date FROM planned_workouts ORDER BY id DESC;"
         )
+
+    def delete_all(self) -> None:
+        self._delete_all("planned_workouts")
 
 
 class PlannedExerciseRepository(BaseRepository):

--- a/rest_api.py
+++ b/rest_api.py
@@ -133,6 +133,28 @@ class GymAPI:
                 for sid, reps, weight, rpe in sets
             ]
 
+        @self.app.post("/settings/delete_all")
+        def delete_all(confirmation: str):
+            if confirmation != "Yes, I confirm":
+                return {"status": "confirmation_failed"}
+            self.workouts.delete_all()
+            self.planned_workouts.delete_all()
+            return {"status": "deleted"}
+
+        @self.app.post("/settings/delete_logged")
+        def delete_logged(confirmation: str):
+            if confirmation != "Yes, I confirm":
+                return {"status": "confirmation_failed"}
+            self.workouts.delete_all()
+            return {"status": "deleted"}
+
+        @self.app.post("/settings/delete_planned")
+        def delete_planned(confirmation: str):
+            if confirmation != "Yes, I confirm":
+                return {"status": "confirmation_failed"}
+            self.planned_workouts.delete_all()
+            return {"status": "deleted"}
+
 
 api = GymAPI()
 app = api.app

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -41,11 +41,13 @@ class GymApp:
 
     def run(self) -> None:
         st.title("Workout Logger")
-        log_tab, plan_tab = st.tabs(["Log", "Plan"])
+        log_tab, plan_tab, settings_tab = st.tabs(["Log", "Plan", "Settings"])
         with log_tab:
             self._log_tab()
         with plan_tab:
             self._plan_tab()
+        with settings_tab:
+            self._settings_tab()
 
     def _log_tab(self) -> None:
         plans = self.planned_workouts.fetch_all()
@@ -243,6 +245,38 @@ class GymApp:
             st.session_state.pop(f"plan_new_reps_{exercise_id}", None)
             st.session_state.pop(f"plan_new_weight_{exercise_id}", None)
             st.session_state.pop(f"plan_new_rpe_{exercise_id}", None)
+
+    def _settings_tab(self) -> None:
+        st.header("Settings")
+        if "delete_target" not in st.session_state:
+            st.session_state.delete_target = None
+
+        if st.button("Delete All Logged and Planned Workouts"):
+            st.session_state.delete_target = "all"
+        if st.button("Delete All Logged Workouts"):
+            st.session_state.delete_target = "logged"
+        if st.button("Delete All Planned Workouts"):
+            st.session_state.delete_target = "planned"
+
+        target = st.session_state.get("delete_target")
+        if target:
+            with st.modal("Confirm Deletion"):
+                text = st.text_input("Type 'Yes, I confirm' to delete")
+                if st.button("Confirm"):
+                    if text == "Yes, I confirm":
+                        if target == "all":
+                            self.workouts.delete_all()
+                            self.planned_workouts.delete_all()
+                        elif target == "logged":
+                            self.workouts.delete_all()
+                        elif target == "planned":
+                            self.planned_workouts.delete_all()
+                        st.success("Data deleted")
+                        st.session_state.delete_target = None
+                    else:
+                        st.warning("Confirmation failed")
+                if st.button("Cancel"):
+                    st.session_state.delete_target = None
 
 
 if __name__ == "__main__":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,6 +82,47 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), [])
 
+    def test_delete_endpoints(self) -> None:
+        plan_date = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
+
+        self.client.post("/workouts")
+        self.client.post("/planned_workouts", params={"date": plan_date})
+
+        response = self.client.post("/settings/delete_all", params={"confirmation": "Yes, I confirm"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "deleted"})
+
+        response = self.client.get("/workouts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+        response = self.client.get("/planned_workouts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+        self.client.post("/workouts")
+        self.client.post("/planned_workouts", params={"date": plan_date})
+
+        response = self.client.post("/settings/delete_logged", params={"confirmation": "Yes, I confirm"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "deleted"})
+
+        response = self.client.get("/workouts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+        response = self.client.get("/planned_workouts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+
+        response = self.client.post("/settings/delete_planned", params={"confirmation": "Yes, I confirm"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "deleted"})
+
+        response = self.client.get("/planned_workouts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
     def test_plan_workflow(self) -> None:
         plan_date = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
 


### PR DESCRIPTION
## Summary
- add repository helpers for deleting workouts and plans
- expose new deletion endpoints in FastAPI application
- implement Settings tab in Streamlit interface
- describe deletion endpoints in README
- test deletion functionality via REST API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874af0f314c8327a078580469e51be0