### PR TITLE
Fix Streamlit modal error

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -260,7 +260,7 @@ class GymApp:
 
         target = st.session_state.get("delete_target")
         if target:
-            with st.modal("Confirm Deletion"):
+            with st.dialog("Confirm Deletion"):
                 text = st.text_input("Type 'Yes, I confirm' to delete")
                 if st.button("Confirm"):
                     if text == "Yes, I confirm":


### PR DESCRIPTION
## Summary
- update Streamlit UI to use `st.dialog` instead of the deprecated `st.modal`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b542598c8327bd5783a5ae0b6c0e