### PR TITLE
Add muscle alias management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,9 @@ The agent is to always follow there rules:
 8. For testing the agent must create full test data. The agent must predetermine expected resulting data and values and tests may only be seen successfull if they output exactly said expected data and values.
 9. Tests may only use the original functions provided in the code. NO monkeypatching of any kind is allowed.
 10. ALL functionality that is available via the streamlit interface must also be available via REST endpoints. The REST endpoints need to be used for testing because the streamlit interface can not be tested directly.
+
+## Muscle linking
+
+- The settings tab includes a "Muscles" subtab for managing muscle aliases. Users can link two existing muscle names or add a new alias linked to an existing muscle.
+- All muscle dropdowns must list every muscle name stored in the database.
+- Whenever any database query involves a muscle field, linked names must be treated as the same muscle.

--- a/rest_api.py
+++ b/rest_api.py
@@ -9,6 +9,7 @@ from db import (
     PlannedSetRepository,
     EquipmentRepository,
     ExerciseCatalogRepository,
+    MuscleRepository,
 )
 from planner_service import PlannerService
 
@@ -25,6 +26,7 @@ class GymAPI:
         self.planned_sets = PlannedSetRepository(db_path)
         self.equipment = EquipmentRepository(db_path)
         self.exercise_catalog = ExerciseCatalogRepository(db_path)
+        self.muscles = MuscleRepository(db_path)
         self.planner = PlannerService(
             self.workouts,
             self.exercises,
@@ -68,6 +70,20 @@ class GymAPI:
                 return {"id": eid}
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
+
+        @self.app.get("/muscles")
+        def list_muscles():
+            return self.muscles.fetch_all()
+
+        @self.app.post("/muscles/link")
+        def link_muscles(name1: str, name2: str):
+            self.muscles.link(name1, name2)
+            return {"status": "linked"}
+
+        @self.app.post("/muscles/alias")
+        def add_alias(new_name: str, existing: str):
+            self.muscles.add_alias(new_name, existing)
+            return {"status": "added"}
 
         @self.app.get("/exercise_catalog/muscle_groups")
         def list_muscle_groups():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -346,3 +346,28 @@ class APITestCase(unittest.TestCase):
         resp = self.client.delete("/exercise_catalog/Barbell Bench Press")
         self.assertEqual(resp.status_code, 400)
 
+    def test_muscle_alias(self) -> None:
+        resp = self.client.get("/muscles")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("Biceps Brachii", resp.json())
+
+        resp = self.client.post(
+            "/muscles/alias", params={"new_name": "My Biceps", "existing": "Biceps Brachii"}
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.post(
+            "/muscles/link", params={"name1": "My Biceps", "name2": "Brachialis"}
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get("/equipment", params={"muscles": "My Biceps"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("EZ Curl Bar", resp.json())
+
+        resp = self.client.get(
+            "/exercise_catalog", params={"muscles": "My Biceps"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("Pull-up", resp.json())
+


### PR DESCRIPTION
## Summary
- support muscle aliases with new `muscles` table and repository
- expose REST endpoints to list, link and add muscle aliases
- show muscle management subtab in Settings
- treat linked muscles as same when filtering or listing equipment and exercises
- update API tests for new functionality
- document muscle linking rules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874cc9734808327b1242a409810f3c2