### PR TITLE
Implement exercise aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,9 @@ The agent is to always follow there rules:
 - The settings tab includes a "Muscles" subtab for managing muscle aliases. Users can link two existing muscle names or add a new alias linked to an existing muscle.
 - All muscle dropdowns must list every muscle name stored in the database.
 - Whenever any database query involves a muscle field, linked names must be treated as the same muscle.
+
+## Exercise aliases
+
+- The settings tab includes an "Exercise Aliases" subtab for managing exercise name aliases. Users can link two existing exercise names or add a new alias linked to an existing exercise.
+- All exercise dropdowns must list every exercise name stored in the database.
+- Whenever any database query involves an exercise name, linked names must be treated as the same exercise.

--- a/rest_api.py
+++ b/rest_api.py
@@ -10,6 +10,7 @@ from db import (
     EquipmentRepository,
     ExerciseCatalogRepository,
     MuscleRepository,
+    ExerciseNameRepository,
 )
 from planner_service import PlannerService
 
@@ -27,6 +28,7 @@ class GymAPI:
         self.equipment = EquipmentRepository(db_path)
         self.exercise_catalog = ExerciseCatalogRepository(db_path)
         self.muscles = MuscleRepository(db_path)
+        self.exercise_names = ExerciseNameRepository(db_path)
         self.planner = PlannerService(
             self.workouts,
             self.exercises,
@@ -83,6 +85,20 @@ class GymAPI:
         @self.app.post("/muscles/alias")
         def add_alias(new_name: str, existing: str):
             self.muscles.add_alias(new_name, existing)
+            return {"status": "added"}
+
+        @self.app.get("/exercise_names")
+        def list_exercise_names():
+            return self.exercise_names.fetch_all()
+
+        @self.app.post("/exercise_names/link")
+        def link_exercise_names(name1: str, name2: str):
+            self.exercise_names.link(name1, name2)
+            return {"status": "linked"}
+
+        @self.app.post("/exercise_names/alias")
+        def add_exercise_alias(new_name: str, existing: str):
+            self.exercise_names.add_alias(new_name, existing)
             return {"status": "added"}
 
         @self.app.get("/exercise_catalog/muscle_groups")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -11,6 +11,7 @@ from db import (
     EquipmentRepository,
     ExerciseCatalogRepository,
     MuscleRepository,
+    ExerciseNameRepository,
 )
 from planner_service import PlannerService
 
@@ -28,6 +29,7 @@ class GymApp:
         self.equipment = EquipmentRepository()
         self.exercise_catalog = ExerciseCatalogRepository()
         self.muscles_repo = MuscleRepository()
+        self.exercise_names_repo = ExerciseNameRepository()
         self.planner = PlannerService(
             self.workouts,
             self.exercises,
@@ -395,7 +397,7 @@ class GymApp:
                 if st.button("Cancel"):
                     st.session_state.delete_target = None
 
-        eq_tab, mus_tab = st.tabs(["Equipment", "Muscles"])
+        eq_tab, mus_tab, ex_tab = st.tabs(["Equipment", "Muscles", "Exercise Aliases"])
 
         with eq_tab:
             st.header("Equipment Management")
@@ -460,6 +462,28 @@ class GymApp:
             if st.button("Add Alias"):
                 if new_muscle:
                     self.muscles_repo.add_alias(new_muscle, link_to)
+                    st.success("Alias added")
+                else:
+                    st.warning("Name required")
+
+        with ex_tab:
+            st.header("Exercise Aliases")
+            names = self.exercise_names_repo.fetch_all()
+            if names:
+                col1, col2 = st.columns(2)
+                with col1:
+                    e1 = st.selectbox("Exercise 1", names, key="link_ex1")
+                with col2:
+                    e2 = st.selectbox("Exercise 2", names, key="link_ex2")
+                if st.button("Link Exercises"):
+                    self.exercise_names_repo.link(e1, e2)
+                    st.success("Linked")
+
+            new_ex = st.text_input("New Exercise Name", key="new_ex_alias")
+            link_ex = st.selectbox("Link To", names, key="link_ex_to")
+            if st.button("Add Exercise Alias"):
+                if new_ex:
+                    self.exercise_names_repo.add_alias(new_ex, link_ex)
                     st.success("Alias added")
                 else:
                     st.warning("Name required")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -371,3 +371,28 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Pull-up", resp.json())
 
+    def test_exercise_alias(self) -> None:
+        resp = self.client.post(
+            "/exercise_names/alias",
+            params={"new_name": "My Pulls", "existing": "Pull-up"},
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.post(
+            "/exercise_names/link",
+            params={"name1": "My Pulls", "name2": "Chin-up"},
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get("/exercise_catalog/My Pulls")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("Latissimus Dorsi", data["primary_muscle"])
+
+        resp = self.client.get(
+            "/exercise_catalog",
+            params={"muscle_groups": "Back"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("My Pulls", resp.json())
+


### PR DESCRIPTION
## Summary
- support exercise alias names in DB
- expose exercise alias management in API
- add exercise alias editing tab in Streamlit UI
- document exercise alias feature
- test exercise alias workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d1b6083c8327bbbbc5adf0176c16