### PR TITLE
Implement extra math utilities

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,6 +13,10 @@ class MathToolsTestCase(unittest.TestCase):
         self.assertAlmostEqual(MathTools.ALPHA_MAX, 1.0)
         self.assertAlmostEqual(MathTools.FFM_FRACTION, 0.407)
         self.assertAlmostEqual(MathTools.EA_BASELINE, 1.097)
+        self.assertEqual(MathTools.L, 3)
+        self.assertAlmostEqual(MathTools.W1, 0.4)
+        self.assertAlmostEqual(MathTools.W2, 0.3)
+        self.assertAlmostEqual(MathTools.W3, 0.3)
 
     def test_clamp(self) -> None:
         self.assertEqual(MathTools.clamp(5, 0, 10), 5)
@@ -32,6 +36,21 @@ class MathToolsTestCase(unittest.TestCase):
         sets = [(10, 100.0), (5, 150.0)]
         self.assertEqual(MathTools.volume(sets), 10 * 100.0 + 5 * 150.0)
         self.assertEqual(MathTools.volume([]), 0.0)
+
+    def test_experience_score(self) -> None:
+        self.assertEqual(MathTools.experience_score(12, 5), 60)
+        with self.assertRaises(ValueError):
+            MathTools.experience_score(-1, 5)
+
+    def test_basic_threshold(self) -> None:
+        self.assertAlmostEqual(MathTools.basic_threshold(105.0, 100.0), 0.05)
+        with self.assertRaises(ValueError):
+            MathTools.basic_threshold(100.0, 0.0)
+
+    def test_required_progression(self) -> None:
+        self.assertAlmostEqual(MathTools.required_progression(150.0, 120.0, 30), 1.0)
+        with self.assertRaises(ValueError):
+            MathTools.required_progression(150.0, 120.0, 0)
 
 
 if __name__ == '__main__':

--- a/tools.py
+++ b/tools.py
@@ -6,6 +6,10 @@ class MathTools:
     ALPHA_MAX: float = 1.0
     FFM_FRACTION: float = 0.407
     EA_BASELINE: float = 1.097
+    L: int = 3
+    W1: float = 0.4
+    W2: float = 0.3
+    W3: float = 0.3
 
     @staticmethod
     def clamp(value: float, min_value: float, max_value: float) -> float:
@@ -29,3 +33,26 @@ class MathTools:
         for reps, weight in sets:
             vol += reps * weight
         return vol
+
+    @staticmethod
+    def experience_score(months_active: int, workouts_per_month: int) -> int:
+        """Return a simple score reflecting training experience."""
+        if months_active < 0 or workouts_per_month < 0:
+            raise ValueError("inputs must be non-negative")
+        return months_active * workouts_per_month
+
+    @staticmethod
+    def basic_threshold(recent_avg: float, prev_avg: float) -> float:
+        """Compute the relative change between recent and previous averages."""
+        if prev_avg == 0:
+            raise ValueError("prev_avg must not be zero")
+        return (recent_avg - prev_avg) / prev_avg
+
+    @staticmethod
+    def required_progression(
+        target_1rm: float, current_1rm: float, days_remaining: int
+    ) -> float:
+        """Return the daily 1RM progression needed to meet a target."""
+        if days_remaining <= 0:
+            raise ValueError("days_remaining must be positive")
+        return (target_1rm - current_1rm) / days_remaining


### PR DESCRIPTION
## Summary
- add look-back period and plateau detection weights
- implement experience-related math utilities
- test constants and new functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874eb5860b48327b2aa70d6f6e8b95f