### PR TITLE
Add set recommendation feature

### DIFF
--- a/recommendation_service.py
+++ b/recommendation_service.py
@@ -1,0 +1,69 @@
+import datetime
+from db import (
+    WorkoutRepository,
+    ExerciseRepository,
+    SetRepository,
+    ExerciseNameRepository,
+)
+from tools import ExercisePrescription
+
+
+class RecommendationService:
+    """Generate exercise set recommendations based on logged history."""
+
+    def __init__(
+        self,
+        workout_repo: WorkoutRepository,
+        exercise_repo: ExerciseRepository,
+        set_repo: SetRepository,
+        exercise_name_repo: ExerciseNameRepository,
+    ) -> None:
+        self.workouts = workout_repo
+        self.exercises = exercise_repo
+        self.sets = set_repo
+        self.exercise_names = exercise_name_repo
+
+    def has_history(self, exercise_name: str) -> bool:
+        names = self.exercise_names.aliases(exercise_name)
+        history = self.sets.fetch_history_by_names(names)
+        return len(history) > 0
+
+    def recommend_next_set(self, exercise_id: int) -> dict:
+        workout_id, name, _ = self.exercises.fetch_detail(exercise_id)
+        alias_names = self.exercise_names.aliases(name)
+        history = self.sets.fetch_history_by_names(alias_names)
+        if not history:
+            raise ValueError("no history for exercise")
+        reps_list = [int(r[0]) for r in history]
+        weight_list = [float(r[1]) for r in history]
+        rpe_list = [int(r[2]) for r in history]
+        dates = [datetime.date.fromisoformat(r[3]) for r in history]
+        timestamps = list(range(len(dates)))
+        months_active = 1.0
+        workouts_per_month = float(len(set(timestamps)))
+        prescription = ExercisePrescription.exercise_prescription(
+            weight_list,
+            reps_list,
+            timestamps,
+            rpe_list,
+            body_weight=80.0,
+            months_active=months_active,
+            workouts_per_month=workouts_per_month,
+        )
+        current_sets = self.sets.fetch_for_exercise(exercise_id)
+        index = len(current_sets)
+        if index >= len(prescription["prescription"]):
+            raise ValueError("no more sets recommended")
+        data = prescription["prescription"][index]
+        set_id = self.sets.add(
+            exercise_id,
+            int(data["reps"]),
+            float(data["weight"]),
+            int(round(data["target_rpe"])),
+        )
+        return {
+            "id": set_id,
+            "reps": int(data["reps"]),
+            "weight": float(data["weight"]),
+            "rpe": int(round(data["target_rpe"])),
+        }

--- a/rest_api.py
+++ b/rest_api.py
@@ -13,6 +13,7 @@ from db import (
     ExerciseNameRepository,
 )
 from planner_service import PlannerService
+from recommendation_service import RecommendationService
 
 
 class GymAPI:
@@ -36,6 +37,12 @@ class GymAPI:
             self.planned_workouts,
             self.planned_exercises,
             self.planned_sets,
+        )
+        self.recommender = RecommendationService(
+            self.workouts,
+            self.exercises,
+            self.sets,
+            self.exercise_names,
         )
         self.app = FastAPI()
         self._setup_routes()
@@ -334,6 +341,13 @@ class GymAPI:
                 {"id": sid, "reps": reps, "weight": weight, "rpe": rpe}
                 for sid, reps, weight, rpe in sets
             ]
+
+        @self.app.post("/exercises/{exercise_id}/recommend_next")
+        def recommend_next(exercise_id: int):
+            try:
+                return self.recommender.recommend_next_set(exercise_id)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
 
         @self.app.post("/settings/delete_all")
         def delete_all(confirmation: str):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -14,6 +14,7 @@ from db import (
     ExerciseNameRepository,
 )
 from planner_service import PlannerService
+from recommendation_service import RecommendationService
 
 
 class GymApp:
@@ -37,6 +38,12 @@ class GymApp:
             self.planned_workouts,
             self.planned_exercises,
             self.planned_sets,
+        )
+        self.recommender = RecommendationService(
+            self.workouts,
+            self.exercises,
+            self.sets,
+            self.exercise_names_repo,
         )
         self._state_init()
 
@@ -159,6 +166,12 @@ class GymApp:
                     self.sets.update(
                         set_id, int(reps_val), float(weight_val), int(rpe_val)
                     )
+            if self.recommender.has_history(name):
+                if st.button("Recommend Next Set", key=f"rec_next_{exercise_id}"):
+                    try:
+                        self.recommender.recommend_next_set(exercise_id)
+                    except ValueError as e:
+                        st.warning(str(e))
             self._add_set_form(exercise_id)
 
     def _add_set_form(self, exercise_id: int) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -396,3 +396,31 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("My Pulls", resp.json())
 
+    def test_recommend_next_set(self) -> None:
+        self.client.post("/workouts")
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post("/exercises/1/sets", params={"reps": 5, "weight": 100.0, "rpe": 8})
+
+        self.client.post("/workouts")
+        self.client.post(
+            "/workouts/2/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post("/exercises/2/sets", params={"reps": 5, "weight": 105.0, "rpe": 8})
+
+        self.client.post("/workouts")
+        self.client.post(
+            "/workouts/3/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        resp = self.client.post("/exercises/3/recommend_next")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["id"], 3)
+        self.assertEqual(data["reps"], 1)
+        self.assertAlmostEqual(data["weight"], 80.8)
+        self.assertEqual(data["rpe"], 7)
+


### PR DESCRIPTION
## Summary
- add new `RecommendationService` for recommending sets
- extend repositories with helper methods and alias sync
- add REST endpoint `/exercises/{exercise_id}/recommend_next`
- show "Recommend Next Set" button in Streamlit
- test recommendation workflow

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687509d93be08327a92b442a51f1863d