### PR TITLE
Add statistics service

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -15,6 +15,7 @@ from db import (
 )
 from planner_service import PlannerService
 from recommendation_service import RecommendationService
+from stats_service import StatisticsService
 
 
 class GymAPI:
@@ -46,6 +47,10 @@ class GymAPI:
             self.sets,
             self.exercise_names,
             self.settings,
+        )
+        self.statistics = StatisticsService(
+            self.sets,
+            self.exercise_names,
         )
         self.app = FastAPI()
         self._setup_routes()
@@ -351,6 +356,30 @@ class GymAPI:
                 return self.recommender.recommend_next_set(exercise_id)
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
+
+        @self.app.get("/stats/exercise_summary")
+        def stats_exercise_summary(
+            exercise: str = None,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.exercise_summary(
+                exercise,
+                start_date,
+                end_date,
+            )
+
+        @self.app.get("/stats/progression")
+        def stats_progression(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.progression(
+                exercise,
+                start_date,
+                end_date,
+            )
 
         @self.app.get("/settings/general")
         def get_general_settings():

--- a/stats_service.py
+++ b/stats_service.py
@@ -1,0 +1,103 @@
+from typing import List, Optional, Dict
+from db import SetRepository, ExerciseNameRepository
+from tools import MathTools
+
+
+class StatisticsService:
+    """Compute workout statistics for analysis."""
+
+    def __init__(self, set_repo: SetRepository, name_repo: ExerciseNameRepository) -> None:
+        self.sets = set_repo
+        self.exercise_names = name_repo
+
+    def _alias_names(self, exercise: Optional[str]) -> List[str]:
+        if not exercise:
+            return self.exercise_names.fetch_all()
+        return self.exercise_names.aliases(exercise)
+
+    def exercise_history(
+        self,
+        exercise: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Dict[str, float]]:
+        names = self._alias_names(exercise)
+        rows = self.sets.fetch_history_by_names(
+            names,
+            start_date=start_date,
+            end_date=end_date,
+            with_equipment=True,
+        )
+        history = []
+        for reps, weight, rpe, date, ex_name, eq_name in rows:
+            history.append(
+                {
+                    "exercise": ex_name,
+                    "equipment": eq_name,
+                    "date": date,
+                    "reps": int(reps),
+                    "weight": float(weight),
+                    "rpe": int(rpe),
+                    "volume": int(reps) * float(weight),
+                    "est_1rm": MathTools.epley_1rm(float(weight), int(reps)),
+                }
+            )
+        return history
+
+    def exercise_summary(
+        self,
+        exercise: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Dict[str, float]]:
+        names = self._alias_names(exercise)
+        rows = self.sets.fetch_history_by_names(
+            names,
+            start_date=start_date,
+            end_date=end_date,
+            with_equipment=True,
+        )
+        stats: Dict[str, Dict[str, float]] = {}
+        for reps, weight, rpe, date, ex_name, _ in rows:
+            item = stats.setdefault(ex_name, {
+                "volume": 0.0,
+                "rpe_total": 0.0,
+                "count": 0,
+                "max_1rm": 0.0,
+            })
+            vol = int(reps) * float(weight)
+            item["volume"] += vol
+            item["rpe_total"] += int(rpe)
+            item["count"] += 1
+            est = MathTools.epley_1rm(float(weight), int(reps))
+            if est > item["max_1rm"]:
+                item["max_1rm"] = est
+        result = []
+        for name, data in stats.items():
+            result.append(
+                {
+                    "exercise": name,
+                    "volume": round(data["volume"], 2),
+                    "avg_rpe": round(data["rpe_total"] / data["count"], 2),
+                    "max_1rm": round(data["max_1rm"], 2),
+                    "sets": int(data["count"]),
+                }
+            )
+        return sorted(result, key=lambda x: x["exercise"])
+
+    def progression(
+        self,
+        exercise: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Dict[str, float]]:
+        history = self.exercise_history(exercise, start_date, end_date)
+        by_date: Dict[str, float] = {}
+        for item in history:
+            date = item["date"]
+            est = item["est_1rm"]
+            if date not in by_date or est > by_date[date]:
+                by_date[date] = est
+        return [
+            {"date": d, "est_1rm": round(by_date[d], 2)} for d in sorted(by_date)
+        ]


### PR DESCRIPTION
## Summary
- extend `SetRepository.fetch_history_by_names` with filtering capabilities
- add new `StatisticsService` for calculating workout stats
- expose summary and progression endpoints
- integrate statistics into Streamlit UI
- test new statistics endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875329504e48327ad917d2f79c41d95