### PR TITLE
Add daily volume and equipment usage stats

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -381,6 +381,20 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/daily_volume")
+        def stats_daily_volume(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.daily_volume(start_date, end_date)
+
+        @self.app.get("/stats/equipment_usage")
+        def stats_equipment_usage(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.equipment_usage(start_date, end_date)
+
         @self.app.get("/settings/general")
         def get_general_settings():
             return self.settings.all_settings()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -415,6 +415,13 @@ class GymApp:
         )
         st.subheader("Summary")
         st.table(summary)
+        daily = self.stats.daily_volume(start_str, end_str)
+        st.subheader("Daily Volume")
+        if daily:
+            st.line_chart({"Volume": [d["volume"] for d in daily]}, x=[d["date"] for d in daily])
+        equip_stats = self.stats.equipment_usage(start_str, end_str)
+        st.subheader("Equipment Usage")
+        st.table(equip_stats)
         if ex_choice:
             prog = self.stats.progression(ex_choice, start_str, end_str)
             st.subheader("1RM Progression")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -454,3 +454,16 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(len(prog), 1)
         self.assertAlmostEqual(prog[0]["est_1rm"], 139.3, places=1)
 
+        resp = self.client.get("/stats/daily_volume")
+        self.assertEqual(resp.status_code, 200)
+        daily = resp.json()
+        self.assertEqual(len(daily), 1)
+        self.assertAlmostEqual(daily[0]["volume"], 1880.0)
+
+        resp = self.client.get("/stats/equipment_usage")
+        self.assertEqual(resp.status_code, 200)
+        eq_stats = resp.json()
+        self.assertEqual(len(eq_stats), 1)
+        self.assertEqual(eq_stats[0]["equipment"], "Olympic Barbell")
+        self.assertEqual(eq_stats[0]["sets"], 2)
+


### PR DESCRIPTION
## Summary
- expand statistics service with daily volume and equipment usage
- expose new stats via REST API
- show daily volume chart and equipment usage table in the Streamlit stats tab
- test the new REST statistics endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875344c6b288327b6ee3c22baec168e