### PR TITLE
Implement separate progress estimator

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -395,6 +395,18 @@ class GymAPI:
         ):
             return self.statistics.equipment_usage(start_date, end_date)
 
+        @self.app.get("/prediction/progress")
+        def prediction_progress(
+            exercise: str,
+            weeks: int,
+            workouts: int,
+        ):
+            return self.statistics.progress_forecast(
+                exercise,
+                weeks,
+                workouts,
+            )
+
         @self.app.get("/settings/general")
         def get_general_settings():
             return self.settings.all_settings()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -467,3 +467,13 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(eq_stats[0]["equipment"], "Olympic Barbell")
         self.assertEqual(eq_stats[0]["sets"], 2)
 
+        resp = self.client.get(
+            "/prediction/progress",
+            params={"exercise": "Bench Press", "weeks": 2, "workouts": 1},
+        )
+        self.assertEqual(resp.status_code, 200)
+        forecast = resp.json()
+        self.assertEqual(len(forecast), 2)
+        self.assertAlmostEqual(forecast[0]["est_1rm"], 139.3, places=1)
+        self.assertAlmostEqual(forecast[1]["est_1rm"], 139.3, places=1)
+

--- a/tools.py
+++ b/tools.py
@@ -303,6 +303,7 @@ class ExercisePrescription(MathTools):
             result.append(perf_i)
         return result
 
+
     @classmethod
     def _recovery_scores_from_logs(
         cls,
@@ -484,3 +485,54 @@ class ExercisePrescription(MathTools):
             },
         }
         return result
+
+
+
+class ExerciseProgressEstimator(ExercisePrescription):
+    """Utility for forecasting 1RM progression using prescription logic."""
+
+    @classmethod
+    def predict_progress(
+        cls,
+        weights: list[float],
+        reps: list[int],
+        timestamps: list[float],
+        rpe_scores: list[int],
+        weeks: int,
+        workouts_per_week: int,
+        *,
+        body_weight: float,
+        months_active: float,
+        workouts_per_month: float,
+    ) -> list[dict]:
+        """Predict future 1RM values for several weeks."""
+
+        w_hist = list(weights)
+        r_hist = list(reps)
+        t_hist = list(timestamps)
+        rpe_hist = list(rpe_scores)
+        current_time = t_hist[-1] if t_hist else 0.0
+        forecast: list[dict] = []
+
+        for week in range(1, weeks + 1):
+            for _ in range(workouts_per_week):
+                presc = cls.exercise_prescription(
+                    w_hist,
+                    r_hist,
+                    t_hist,
+                    rpe_hist,
+                    body_weight=body_weight,
+                    months_active=months_active,
+                    workouts_per_month=workouts_per_month,
+                )
+                data = presc["prescription"][0]
+                current_time += 1
+                t_hist.append(current_time)
+                w_hist.append(float(data["weight"]))
+                r_hist.append(int(data["reps"]))
+                rpe_hist.append(int(round(data["target_rpe"])))
+
+            est = cls._current_1rm(w_hist, r_hist)
+            forecast.append({"week": week, "est_1rm": round(est, 2)})
+
+        return forecast


### PR DESCRIPTION
## Summary
- add `ExerciseProgressEstimator` as subclass of `ExercisePrescription`
- expose progress forecast via `/prediction/progress` without GUI integration
- adjust `StatisticsService` to use the new estimator
- keep Streamlit setup unchanged

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687538ca07a4832790b2a641af629db5