### PR TITLE
Add new stats distributions

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -395,6 +395,30 @@ class GymAPI:
         ):
             return self.statistics.equipment_usage(start_date, end_date)
 
+        @self.app.get("/stats/rpe_distribution")
+        def stats_rpe_distribution(
+            exercise: str = None,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.rpe_distribution(
+                exercise,
+                start_date,
+                end_date,
+            )
+
+        @self.app.get("/stats/reps_distribution")
+        def stats_reps_distribution(
+            exercise: str = None,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.reps_distribution(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/prediction/progress")
         def prediction_progress(
             exercise: str,

--- a/stats_service.py
+++ b/stats_service.py
@@ -200,3 +200,47 @@ class StatisticsService:
                 }
             )
         return result
+
+    def rpe_distribution(
+        self,
+        exercise: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Dict[str, int]]:
+        """Return a distribution of RPE values for the given exercise."""
+        names = self._alias_names(exercise)
+        rows = self.sets.fetch_history_by_names(
+            names,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        dist: Dict[int, int] = {}
+        for _reps, _weight, rpe, _date in rows:
+            key = int(rpe)
+            dist[key] = dist.get(key, 0) + 1
+        result = []
+        for r in sorted(dist):
+            result.append({"rpe": r, "count": dist[r]})
+        return result
+
+    def reps_distribution(
+        self,
+        exercise: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Dict[str, int]]:
+        """Return a distribution of repetition counts."""
+        names = self._alias_names(exercise)
+        rows = self.sets.fetch_history_by_names(
+            names,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        dist: Dict[int, int] = {}
+        for reps, _weight, _rpe, _date in rows:
+            key = int(reps)
+            dist[key] = dist.get(key, 0) + 1
+        result = []
+        for r in sorted(dist):
+            result.append({"reps": r, "count": dist[r]})
+        return result

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -422,6 +422,22 @@ class GymApp:
         equip_stats = self.stats.equipment_usage(start_str, end_str)
         st.subheader("Equipment Usage")
         st.table(equip_stats)
+        rpe_dist = self.stats.rpe_distribution(
+            ex_choice if ex_choice else None,
+            start_str,
+            end_str,
+        )
+        st.subheader("RPE Distribution")
+        if rpe_dist:
+            st.bar_chart({"Count": [d["count"] for d in rpe_dist]}, x=[str(d["rpe"]) for d in rpe_dist])
+        reps_dist = self.stats.reps_distribution(
+            ex_choice if ex_choice else None,
+            start_str,
+            end_str,
+        )
+        st.subheader("Reps Distribution")
+        if reps_dist:
+            st.bar_chart({"Count": [d["count"] for d in reps_dist]}, x=[str(d["reps"]) for d in reps_dist])
         if ex_choice:
             prog = self.stats.progression(ex_choice, start_str, end_str)
             st.subheader("1RM Progression")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -468,6 +468,30 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(eq_stats[0]["sets"], 2)
 
         resp = self.client.get(
+            "/stats/rpe_distribution",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        rpe = resp.json()
+        self.assertEqual(len(rpe), 2)
+        self.assertEqual(rpe[0]["rpe"], 8)
+        self.assertEqual(rpe[0]["count"], 1)
+        self.assertEqual(rpe[1]["rpe"], 9)
+        self.assertEqual(rpe[1]["count"], 1)
+
+        resp = self.client.get(
+            "/stats/reps_distribution",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        rep_dist = resp.json()
+        self.assertEqual(len(rep_dist), 2)
+        self.assertEqual(rep_dist[0]["reps"], 8)
+        self.assertEqual(rep_dist[0]["count"], 1)
+        self.assertEqual(rep_dist[1]["reps"], 10)
+        self.assertEqual(rep_dist[1]["count"], 1)
+
+        resp = self.client.get(
             "/prediction/progress",
             params={"exercise": "Bench Press", "weeks": 2, "workouts": 1},
         )


### PR DESCRIPTION
## Summary
- extend statistics service with RPE and rep distributions
- expose new stats endpoints in REST API
- show RPE and rep distribution charts in stats tab
- cover new endpoints with tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68754fd130c08327b6d9de929e03146c