### PR TITLE
Enhance Streamlit GUI with exercise history

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -401,6 +401,18 @@ class GymAPI:
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
 
+        @self.app.get("/stats/exercise_history")
+        def stats_exercise_history(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.exercise_history(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/stats/exercise_summary")
         def stats_exercise_summary(
             exercise: str = None,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -213,6 +213,10 @@ class GymApp:
                     cols[4].write(start_time)
                 if end_time:
                     cols[5].write(end_time)
+            hist = self.stats.exercise_history(name)
+            if hist:
+                with st.expander("History (last 5)"):
+                    st.table(hist[-5:][::-1])
             if self.recommender.has_history(name):
                 if st.button("Recommend Next Set", key=f"rec_next_{exercise_id}"):
                     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -482,6 +482,16 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(rpe[1]["count"], 1)
 
         resp = self.client.get(
+            "/stats/exercise_history",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        history = resp.json()
+        self.assertEqual(len(history), 2)
+        self.assertEqual(history[0]["reps"], 10)
+        self.assertEqual(history[1]["weight"], 110.0)
+
+        resp = self.client.get(
             "/stats/reps_distribution",
             params={"exercise": "Bench Press"},
         )


### PR DESCRIPTION
## Summary
- expose new REST endpoint `/stats/exercise_history`
- show last five sets for an exercise in the Streamlit UI
- test new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875d9b492588327b8fa76d98a385363