### PR TITLE
Integrate TUT into exercise prescription

### DIFF
--- a/db.py
+++ b/db.py
@@ -507,11 +507,14 @@ class SetRepository(BaseRepository):
         end_date: Optional[str] = None,
         equipment: Optional[List[str]] = None,
         with_equipment: bool = False,
+        with_duration: bool = False,
     ) -> List[Tuple]:
         placeholders = ", ".join(["?" for _ in names])
         select = "SELECT s.reps, s.weight, s.rpe, w.date"
         if with_equipment:
             select += ", e.name, e.equipment_name"
+        if with_duration:
+            select += ", s.start_time, s.end_time"
         query = (
             f"{select} FROM sets s "
             "JOIN exercises e ON s.exercise_id = e.id "

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -66,6 +66,7 @@ class MathToolsTestCase(unittest.TestCase):
         reps = [5, 5, 5, 5, 5]
         timestamps = [0, 7, 14, 21, 28]
         rpe = [8, 8, 8, 8, 8]
+        durations = [45, 46, 44, 47, 48]
         calories = [2720, 2720, 2720, 2720, 2176]
         sleep_hours = [8, 8, 8, 8, 8]
         sleep_quality = [4, 4, 4, 4, 4]
@@ -75,6 +76,7 @@ class MathToolsTestCase(unittest.TestCase):
             reps,
             timestamps,
             rpe,
+            durations=durations,
             body_weight=80.0,
             months_active=12,
             workouts_per_month=8,


### PR DESCRIPTION
## Summary
- allow fetching set history with durations
- use measured set duration when generating recommendations
- incorporate TUT into fatigue, deload, and RPE logic
- expose durations option in exercise prescription
- adapt tests for new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f3ee6ad483278dd8ff2f072b3058