### PR TITLE
Add rest time tracking to prescriptions

### DIFF
--- a/recommendation_service.py
+++ b/recommendation_service.py
@@ -41,6 +41,8 @@ class RecommendationService:
         weight_list = [float(r[1]) for r in history]
         rpe_list = [int(r[2]) for r in history]
         durations = []
+        rest_times: list[float] = []
+        prev_end: datetime.datetime | None = None
         for r in history:
             start = r[4]
             end = r[5]
@@ -48,8 +50,14 @@ class RecommendationService:
                 t0 = datetime.datetime.fromisoformat(start)
                 t1 = datetime.datetime.fromisoformat(end)
                 durations.append((t1 - t0).total_seconds())
+                if prev_end is not None:
+                    rest_times.append((t0 - prev_end).total_seconds())
+                else:
+                    rest_times.append(90.0)
+                prev_end = t1
             else:
                 durations.append(0.0)
+                rest_times.append(90.0 if prev_end is None else 0.0)
         dates = [datetime.date.fromisoformat(r[3]) for r in history]
         timestamps = list(range(len(dates)))
         months_active = self.settings.get_float("months_active", 1.0)
@@ -60,6 +68,7 @@ class RecommendationService:
             timestamps,
             rpe_list,
             durations=durations,
+            rest_times=rest_times,
             body_weight=self.settings.get_float("body_weight", 80.0),
             months_active=months_active,
             workouts_per_month=workouts_per_month,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -70,6 +70,7 @@ class MathToolsTestCase(unittest.TestCase):
         calories = [2720, 2720, 2720, 2720, 2176]
         sleep_hours = [8, 8, 8, 8, 8]
         sleep_quality = [4, 4, 4, 4, 4]
+        rest_times = [240, 240, 240, 240, 240]
 
         result = ExercisePrescription.exercise_prescription(
             weights,
@@ -77,6 +78,7 @@ class MathToolsTestCase(unittest.TestCase):
             timestamps,
             rpe,
             durations=durations,
+            rest_times=rest_times,
             body_weight=80.0,
             months_active=12,
             workouts_per_month=8,


### PR DESCRIPTION
## Summary
- extend fatigue model with rest efficiency parameter
- adjust exercise_prescription to account for rest times
- compute rest time intervals in recommendation service
- update tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687600c544808327aed7fa4adea50761