### PR TITLE
Add workout type and recovery-aware prescription

### DIFF
--- a/planner_service.py
+++ b/planner_service.py
@@ -29,7 +29,9 @@ class PlannerService:
         self.planned_sets = plan_set_repo
 
     def create_workout_from_plan(self, plan_id: int) -> int:
-        workout_id = self.workouts.create(datetime.date.today().isoformat())
+        workout_id = self.workouts.create(
+            datetime.date.today().isoformat(), "strength"
+        )
         exercises = self.planned_exercises.fetch_for_workout(plan_id)
         for ex_id, name, equipment in exercises:
             new_ex_id = self.exercises.add(workout_id, name, equipment)

--- a/recommendation_service.py
+++ b/recommendation_service.py
@@ -34,7 +34,9 @@ class RecommendationService:
     def recommend_next_set(self, exercise_id: int) -> dict:
         workout_id, name, _ = self.exercises.fetch_detail(exercise_id)
         alias_names = self.exercise_names.aliases(name)
-        history = self.sets.fetch_history_by_names(alias_names, with_duration=True)
+        history = self.sets.fetch_history_by_names(
+            alias_names, with_duration=True, with_workout_id=True
+        )
         if not history:
             raise ValueError("no history for exercise")
         reps_list = [int(r[0]) for r in history]
@@ -43,9 +45,11 @@ class RecommendationService:
         durations = []
         rest_times: list[float] = []
         prev_end: datetime.datetime | None = None
+        session_map: dict[int, dict] = {}
         for r in history:
             start = r[4]
             end = r[5]
+            wid = r[6]
             if start and end:
                 t0 = datetime.datetime.fromisoformat(start)
                 t1 = datetime.datetime.fromisoformat(end)
@@ -58,10 +62,59 @@ class RecommendationService:
             else:
                 durations.append(0.0)
                 rest_times.append(90.0 if prev_end is None else 0.0)
+            sess = session_map.setdefault(wid, {"volume": 0.0, "rpe": []})
+            sess["volume"] += int(r[0]) * float(r[1])
+            sess["rpe"].append(int(r[2]))
         dates = [datetime.date.fromisoformat(r[3]) for r in history]
         timestamps = list(range(len(dates)))
         months_active = self.settings.get_float("months_active", 1.0)
         workouts_per_month = float(len(set(timestamps)))
+
+        sessions: list[dict] = []
+        for wid in session_map:
+            wid_d, date, start, end, t_type = self.workouts.fetch_detail(wid)
+            sessions.append(
+                {
+                    "id": wid_d,
+                    "start": datetime.datetime.fromisoformat(start)
+                    if start
+                    else None,
+                    "end": datetime.datetime.fromisoformat(end) if end else None,
+                    "type": t_type,
+                    "volume": session_map[wid]["volume"],
+                    "avg_rpe": float(sum(session_map[wid]["rpe"]) / len(session_map[wid]["rpe"]))
+                    if session_map[wid]["rpe"]
+                    else 6.0,
+                }
+            )
+        sessions.sort(key=lambda x: x["start"] or datetime.datetime.min)
+        recovery_times: list[float] = []
+        optimal_times: list[float] = []
+        for prev, curr in zip(sessions, sessions[1:]):
+            if prev["end"] and curr["start"]:
+                rt = (curr["start"] - prev["end"]).total_seconds() / 3600
+                base = 48 + (prev["avg_rpe"] - 6) * 12
+                if prev["type"] == "highintensity":
+                    base = max(base, 72)
+                opt = ExercisePrescription.clamp(base, 24, 96)
+                recovery_times.append(rt)
+                optimal_times.append(opt)
+        recovery_qualities = [
+            ExercisePrescription.clamp(rt / ot, 0.3, 2.0)
+            for rt, ot in zip(recovery_times, optimal_times)
+        ]
+        recovery_quality_mean = (
+            float(sum(recovery_qualities[-ExercisePrescription.L:]) / len(recovery_qualities[-ExercisePrescription.L:]))
+            if recovery_qualities
+            else 1.0
+        )
+        avg_recovery_time = (
+            float(sum(recovery_times[-4:]) / len(recovery_times[-4:]))
+            if len(recovery_times) >= 4
+            else 72.0
+        )
+        frequency_factor = ExercisePrescription.clamp(72 / avg_recovery_time, 0.5, 2.0)
+        session_volumes = [s["volume"] for s in sessions[:-1]]
         prescription = ExercisePrescription.exercise_prescription(
             weight_list,
             reps_list,
@@ -69,6 +122,11 @@ class RecommendationService:
             rpe_list,
             durations=durations,
             rest_times=rest_times,
+            recovery_times=recovery_times,
+            optimal_recovery_times=optimal_times,
+            session_volumes=session_volumes,
+            recovery_quality_mean=recovery_quality_mean,
+            frequency_factor=frequency_factor,
             body_weight=self.settings.get_float("body_weight", 80.0),
             months_active=months_active,
             workouts_per_month=workouts_per_month,

--- a/rest_api.py
+++ b/rest_api.py
@@ -241,24 +241,32 @@ class GymAPI:
                 raise HTTPException(status_code=400, detail=str(e))
 
         @self.app.post("/workouts")
-        def create_workout():
-            workout_id = self.workouts.create(datetime.date.today().isoformat())
+        def create_workout(training_type: str = "strength"):
+            workout_id = self.workouts.create(
+                datetime.date.today().isoformat(), training_type
+            )
             return {"id": workout_id}
 
         @self.app.get("/workouts")
         def list_workouts():
             workouts = self.workouts.fetch_all_workouts()
-            return [{"id": wid, "date": date} for wid, date in workouts]
+            return [{"id": wid, "date": date} for wid, date, *_ in workouts]
 
         @self.app.get("/workouts/{workout_id}")
         def get_workout(workout_id: int):
-            wid, date, start_time, end_time = self.workouts.fetch_detail(workout_id)
+            wid, date, start_time, end_time, training_type = self.workouts.fetch_detail(workout_id)
             return {
                 "id": wid,
                 "date": date,
                 "start_time": start_time,
                 "end_time": end_time,
+                "training_type": training_type,
             }
+
+        @self.app.put("/workouts/{workout_id}/type")
+        def update_workout_type(workout_id: int, training_type: str):
+            self.workouts.set_training_type(workout_id, training_type)
+            return {"status": "updated"}
 
         @self.app.post("/workouts/{workout_id}/start")
         def start_workout(workout_id: int):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -103,8 +103,12 @@ class GymApp:
 
     def _workout_section(self) -> None:
         st.header("Workouts")
+        training_options = ["strength", "hypertrophy", "highintensity"]
+        new_type = st.selectbox("Training Type", training_options, key="new_workout_type")
         if st.button("New Workout"):
-            new_id = self.workouts.create(datetime.date.today().isoformat())
+            new_id = self.workouts.create(
+                datetime.date.today().isoformat(), new_type
+            )
             st.session_state.selected_workout = new_id
         workouts = self.workouts.fetch_all_workouts()
         options = {str(w[0]): w for w in workouts}
@@ -117,7 +121,8 @@ class GymApp:
             detail = self.workouts.fetch_detail(int(selected))
             start_time = detail[2]
             end_time = detail[3]
-            cols = st.columns(2)
+            current_type = detail[4]
+            cols = st.columns(3)
             if cols[0].button("Start Workout", key=f"start_workout_{selected}"):
                 self.workouts.set_start_time(
                     int(selected),
@@ -128,6 +133,14 @@ class GymApp:
                     int(selected),
                     datetime.datetime.now().isoformat(timespec="seconds"),
                 )
+            type_choice = cols[2].selectbox(
+                "Type",
+                training_options,
+                index=training_options.index(current_type),
+                key=f"type_select_{selected}"
+            )
+            if cols[2].button("Save", key=f"save_type_{selected}"):
+                self.workouts.set_training_type(int(selected), type_choice)
             if start_time:
                 st.write(f"Start: {start_time}")
             if end_time:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -514,7 +514,7 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(forecast[1]["est_1rm"], 139.3, places=1)
 
     def test_timestamps(self) -> None:
-        resp = self.client.post("/workouts")
+        resp = self.client.post("/workouts", params={"training_type": "strength"})
         self.assertEqual(resp.status_code, 200)
         wid = resp.json()["id"]
 
@@ -525,6 +525,7 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get(f"/workouts/{wid}")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["start_time"], start_ts)
+        self.assertEqual(resp.json()["training_type"], "strength")
 
         resp = self.client.post(f"/workouts/{wid}/finish")
         self.assertEqual(resp.status_code, 200)
@@ -557,4 +558,20 @@ class APITestCase(unittest.TestCase):
 
         resp = self.client.get(f"/sets/{sid}")
         self.assertEqual(resp.json()["end_time"], set_end)
+
+    def test_training_type(self) -> None:
+        resp = self.client.post("/workouts", params={"training_type": "hypertrophy"})
+        self.assertEqual(resp.status_code, 200)
+        wid = resp.json()["id"]
+
+        resp = self.client.get(f"/workouts/{wid}")
+        self.assertEqual(resp.json()["training_type"], "hypertrophy")
+
+        resp = self.client.put(
+            f"/workouts/{wid}/type", params={"training_type": "strength"}
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get(f"/workouts/{wid}")
+        self.assertEqual(resp.json()["training_type"], "strength")
 


### PR DESCRIPTION
## Summary
- support tracking workout `training_type` in the database
- expose workout type via REST API and streamlit
- integrate workout type editing in UI
- compute recovery-aware fatigue and volume adjustments
- expose endpoints to update workout type
- adjust tests for new functionality
- fuse fatigue models using both per-set data and recovery ratios

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876191a21508327b861a513de09d11c