### PR TITLE
Add forecast chart to GUI

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -51,6 +51,7 @@ class GymAPI:
         self.statistics = StatisticsService(
             self.sets,
             self.exercise_names,
+            self.settings,
         )
         self.app = FastAPI()
         self._setup_routes()

--- a/stats_service.py
+++ b/stats_service.py
@@ -1,6 +1,6 @@
 import datetime
 from typing import List, Optional, Dict
-from db import SetRepository, ExerciseNameRepository
+from db import SetRepository, ExerciseNameRepository, SettingsRepository
 from tools import MathTools, ExerciseProgressEstimator
 
 
@@ -11,9 +11,11 @@ class StatisticsService:
         self,
         set_repo: SetRepository,
         name_repo: ExerciseNameRepository,
+        settings_repo: SettingsRepository | None = None,
     ) -> None:
         self.sets = set_repo
         self.exercise_names = name_repo
+        self.settings = settings_repo
 
     def _alias_names(self, exercise: Optional[str]) -> List[str]:
         if not exercise:
@@ -153,9 +155,17 @@ class StatisticsService:
         rpe_scores = [int(r[2]) for r in rows]
         times = list(range(len(rows)))
 
-        months_active = 1.0
+        months_active = (
+            self.settings.get_float("months_active", 1.0)
+            if self.settings
+            else 1.0
+        )
         workouts_per_month = float(len(set(times)))
-        body_weight = 80.0
+        body_weight = (
+            self.settings.get_float("body_weight", 80.0)
+            if self.settings
+            else 80.0
+        )
 
         return ExerciseProgressEstimator.predict_progress(
             weights,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -52,6 +52,7 @@ class GymApp:
         self.stats = StatisticsService(
             self.sets,
             self.exercise_names_repo,
+            self.settings_repo,
         )
         self._state_init()
 
@@ -496,6 +497,16 @@ class GymApp:
             st.subheader("1RM Progression")
             if prog:
                 st.line_chart({"1RM": [p["est_1rm"] for p in prog]}, x=[p["date"] for p in prog])
+            self._progress_forecast_section(ex_choice)
+
+    def _progress_forecast_section(self, exercise: str) -> None:
+        st.subheader("Progress Forecast")
+        weeks = st.slider("Weeks", 1, 12, 4, key="forecast_weeks")
+        wpw = st.slider("Workouts per Week", 1, 7, 3, key="forecast_wpw")
+        if st.button("Show Forecast"):
+            forecast = self.stats.progress_forecast(exercise, weeks, wpw)
+            if forecast:
+                st.line_chart({"Est 1RM": [f["est_1rm"] for f in forecast]}, x=[str(f["week"]) for f in forecast])
 
     def _settings_tab(self) -> None:
         st.header("Settings")


### PR DESCRIPTION
## Summary
- let `StatisticsService` read configuration from `SettingsRepository`
- pass settings repo to API and GUI services
- add progress forecast section with chart in the stats tab

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765f8730e88327b6ce1e9cd1d64240