### PR TITLE
Add dashboard tab with overview stats

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -494,6 +494,13 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/overview")
+        def stats_overview(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.overview(start_date, end_date)
+
         @self.app.get("/prediction/progress")
         def prediction_progress(
             exercise: str,

--- a/stats_service.py
+++ b/stats_service.py
@@ -254,3 +254,36 @@ class StatisticsService:
         for r in sorted(dist):
             result.append({"reps": r, "count": dist[r]})
         return result
+
+    def overview(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, float]:
+        """Return aggregated workout statistics."""
+        names = self.exercise_names.fetch_all()
+        rows = self.sets.fetch_history_by_names(
+            names,
+            start_date=start_date,
+            end_date=end_date,
+            with_equipment=True,
+            with_workout_id=True,
+        )
+        if not rows:
+            return {"workouts": 0, "volume": 0.0, "avg_rpe": 0.0, "exercises": 0}
+        workout_ids = set()
+        exercises = set()
+        volume = 0.0
+        rpe_total = 0.0
+        for reps, weight, rpe, _date, ex_name, _eq, wid in rows:
+            workout_ids.add(wid)
+            exercises.add(ex_name)
+            volume += int(reps) * float(weight)
+            rpe_total += int(rpe)
+        avg_rpe = rpe_total / len(rows)
+        return {
+            "workouts": len(workout_ids),
+            "volume": round(volume, 2),
+            "avg_rpe": round(avg_rpe, 2),
+            "exercises": len(exercises),
+        }

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -64,14 +64,39 @@ class GymApp:
         if "selected_planned_workout" not in st.session_state:
             st.session_state.selected_planned_workout = None
 
+    def _dashboard_tab(self) -> None:
+        st.header("Dashboard")
+        col1, col2 = st.columns(2)
+        with col1:
+            start = st.date_input(
+                "Start",
+                datetime.date.today() - datetime.timedelta(days=30),
+                key="dash_start",
+            )
+        with col2:
+            end = st.date_input("End", datetime.date.today(), key="dash_end")
+        stats = self.stats.overview(start.isoformat(), end.isoformat())
+        m1, m2, m3, m4 = st.columns(4)
+        m1.metric("Workouts", stats["workouts"])
+        m2.metric("Volume", stats["volume"])
+        m3.metric("Avg RPE", stats["avg_rpe"])
+        m4.metric("Exercises", stats["exercises"])
+        daily = self.stats.daily_volume(start.isoformat(), end.isoformat())
+        st.subheader("Daily Volume")
+        if daily:
+            st.line_chart({"Volume": [d["volume"] for d in daily]}, x=[d["date"] for d in daily])
+
     def run(self) -> None:
         st.title("Workout Logger")
-        log_tab, plan_tab, stats_tab, settings_tab = st.tabs([
+        dash_tab, log_tab, plan_tab, stats_tab, settings_tab = st.tabs([
+            "Dashboard",
             "Log",
             "Plan",
             "Stats",
             "Settings",
         ])
+        with dash_tab:
+            self._dashboard_tab()
         with log_tab:
             self._log_tab()
         with plan_tab:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -517,6 +517,14 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(forecast[0]["est_1rm"], 139.3, places=1)
         self.assertAlmostEqual(forecast[1]["est_1rm"], 139.3, places=1)
 
+        resp = self.client.get("/stats/overview")
+        self.assertEqual(resp.status_code, 200)
+        overview = resp.json()
+        self.assertEqual(overview["workouts"], 1)
+        self.assertAlmostEqual(overview["volume"], 1880.0)
+        self.assertAlmostEqual(overview["avg_rpe"], 8.5)
+        self.assertEqual(overview["exercises"], 1)
+
     def test_timestamps(self) -> None:
         resp = self.client.post("/workouts", params={"training_type": "strength"})
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- create new StatsService.overview for aggregated stats
- expose new `/stats/overview` endpoint in REST API
- add dashboard tab in Streamlit UI showing overview metrics
- test the new overview endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687661694e0883278f4aaea1e0e6fe05