### PR TITLE
Add workout export and enhanced dashboard

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -1,5 +1,5 @@
 import datetime
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 from db import (
     WorkoutRepository,
     ExerciseRepository,
@@ -273,6 +273,17 @@ class GymAPI:
                 "end_time": end_time,
                 "training_type": training_type,
             }
+
+        @self.app.get("/workouts/{workout_id}/export_csv")
+        def export_workout_csv(workout_id: int):
+            data = self.sets.export_workout_csv(workout_id)
+            return Response(
+                content=data,
+                media_type="text/csv",
+                headers={
+                    "Content-Disposition": f"attachment; filename=workout_{workout_id}.csv"
+                },
+            )
 
         @self.app.put("/workouts/{workout_id}/type")
         def update_workout_type(workout_id: int, training_type: str):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -85,6 +85,13 @@ class GymApp:
         st.subheader("Daily Volume")
         if daily:
             st.line_chart({"Volume": [d["volume"] for d in daily]}, x=[d["date"] for d in daily])
+        exercises = [""] + self.exercise_names_repo.fetch_all()
+        ex_choice = st.selectbox("Exercise Progression", exercises, key="dash_ex")
+        if ex_choice:
+            prog = self.stats.progression(ex_choice, start.isoformat(), end.isoformat())
+            st.subheader("1RM Progression")
+            if prog:
+                st.line_chart({"1RM": [p["est_1rm"] for p in prog]}, x=[p["date"] for p in prog])
 
     def run(self) -> None:
         st.title("Workout Logger")
@@ -171,6 +178,14 @@ class GymApp:
                 st.write(f"Start: {start_time}")
             if end_time:
                 st.write(f"End: {end_time}")
+            csv_data = self.sets.export_workout_csv(int(selected))
+            st.download_button(
+                label="Export CSV",
+                data=csv_data,
+                file_name=f"workout_{selected}.csv",
+                mime="text/csv",
+                key=f"export_{selected}",
+            )
 
     def _exercise_section(self) -> None:
         st.header("Exercises")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,6 +70,12 @@ class APITestCase(unittest.TestCase):
             response.json(), [{"id": 1, "reps": 12, "weight": 105.0, "rpe": 9}]
         )
 
+        response = self.client.get("/workouts/1/export_csv")
+        self.assertEqual(response.status_code, 200)
+        csv_text = response.text.strip().splitlines()
+        self.assertEqual(csv_text[0], "Exercise,Equipment,Reps,Weight,RPE,Start,End")
+        self.assertIn("Bench Press", csv_text[1])
+
         response = self.client.delete("/sets/1")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"status": "deleted"})


### PR DESCRIPTION
## Summary
- implement `SetRepository.export_workout_csv` with helper query
- expose new `/workouts/{id}/export_csv` API endpoint
- allow exporting workouts in the Streamlit interface
- display 1RM progression chart on dashboard
- test new CSV export endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687663fd549483278759f913ab06a2ee