### PR TITLE
Integrate advanced pyramid test analysis

### DIFF
--- a/recommendation_service.py
+++ b/recommendation_service.py
@@ -130,6 +130,7 @@ class RecommendationService:
             body_weight=self.settings.get_float("body_weight", 80.0),
             months_active=months_active,
             workouts_per_month=workouts_per_month,
+            exercise_name=name,
         )
         current_sets = self.sets.fetch_for_exercise(exercise_id)
         index = len(current_sets)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -619,7 +619,16 @@ class APITestCase(unittest.TestCase):
 
     def test_pyramid_tests(self) -> None:
         today = datetime.date.today().isoformat()
-        resp = self.client.post("/pyramid_tests", params={"weights": "100|110"})
+        resp = self.client.post(
+            "/pyramid_tests",
+            params={
+                "weights": "100|110",
+                "exercise_name": "Bench Press",
+                "equipment_name": "Olympic Barbell",
+                "starting_weight": 100.0,
+                "failed_weight": 115.0,
+            },
+        )
         self.assertEqual(resp.status_code, 200)
         tid1 = resp.json()["id"]
 
@@ -635,6 +644,12 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         tid2 = resp.json()["id"]
         self.assertEqual(tid2, tid1 + 1)
+
+        resp_invalid = self.client.post(
+            "/pyramid_tests",
+            params={"weights": "130|120", "starting_weight": 100.0, "max_achieved": 90.0},
+        )
+        self.assertEqual(resp_invalid.status_code, 400)
 
         resp = self.client.get("/pyramid_tests")
         self.assertEqual(resp.status_code, 200)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -179,6 +179,30 @@ class MathToolsTestCase(unittest.TestCase):
         self.assertGreater(metrics["efficiency_score"], 1.0)
         self.assertAlmostEqual(metrics["strength_reserve"], (120.0 - 110.0) / 110.0, places=2)
 
+    def test_pyramid_trend_and_plateau(self) -> None:
+        ts = [0, 7, 14, 21, 28]
+        rms = [100.0, 105.0, 110.0, 112.5, 115.0]
+        trend = ExercisePrescription._analyze_1rm_trends(ts, rms)
+        self.assertEqual(trend["trend"], "linear")
+        plateau = ExercisePrescription._pyramid_plateau_detection(ts, rms)
+        self.assertLessEqual(plateau, 1.0)
+
+    def test_validate_pyramid_test(self) -> None:
+        test = {
+            "starting_weight": 100.0,
+            "successful_weights": [100.0, 110.0, 120.0],
+            "failed_weight": 125.0,
+            "max_achieved": 120.0,
+        }
+        self.assertTrue(ExercisePrescription._validate_pyramid_test(test))
+        test_bad = {
+            "starting_weight": 100.0,
+            "successful_weights": [120.0, 110.0],
+            "failed_weight": 140.0,
+            "max_achieved": 120.0,
+        }
+        self.assertFalse(ExercisePrescription._validate_pyramid_test(test_bad))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend REST API for full pyramid test metadata
- validate pyramid tests and store detailed fields
- weigh latest pyramid test against calculated 1RM
- analyze pyramid test trends and plateaus
- expose exercise name to prescription logic
- add unit tests for new analysis helpers and API behaviour

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6876a88450248327adf1fccb0c03933e