### PR TITLE
Add workout history tab and endpoint

### DIFF
--- a/db.py
+++ b/db.py
@@ -393,10 +393,23 @@ class WorkoutRepository(BaseRepository):
             (date, training_type),
         )
 
-    def fetch_all_workouts(self) -> List[Tuple[int, str, Optional[str], Optional[str], str]]:
-        return self.fetch_all(
-            "SELECT id, date, start_time, end_time, training_type FROM workouts ORDER BY id DESC;"
+    def fetch_all_workouts(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Tuple[int, str, Optional[str], Optional[str], str]]:
+        query = (
+            "SELECT id, date, start_time, end_time, training_type FROM workouts"
         )
+        params: list[str] = []
+        if start_date:
+            query += " WHERE date >= ?"
+            params.append(start_date)
+        if end_date:
+            query += " AND date <= ?" if start_date else " WHERE date <= ?"
+            params.append(end_date)
+        query += " ORDER BY id DESC;"
+        return self.fetch_all(query, tuple(params))
 
     def set_start_time(self, workout_id: int, timestamp: str) -> None:
         self.execute(

--- a/rest_api.py
+++ b/rest_api.py
@@ -264,9 +264,33 @@ class GymAPI:
             return {"id": workout_id}
 
         @self.app.get("/workouts")
-        def list_workouts():
-            workouts = self.workouts.fetch_all_workouts()
+        def list_workouts(start_date: str = None, end_date: str = None):
+            workouts = self.workouts.fetch_all_workouts(start_date, end_date)
             return [{"id": wid, "date": date} for wid, date, *_ in workouts]
+
+        @self.app.get("/workouts/history")
+        def workout_history(
+            start_date: str,
+            end_date: str,
+            training_type: str = None,
+        ):
+            workouts = self.workouts.fetch_all_workouts(start_date, end_date)
+            result = []
+            for wid, date, _s, _e, t_type in workouts:
+                if training_type and t_type != training_type:
+                    continue
+                summary = self.sets.workout_summary(wid)
+                result.append(
+                    {
+                        "id": wid,
+                        "date": date,
+                        "training_type": t_type,
+                        "volume": summary["volume"],
+                        "sets": summary["sets"],
+                        "avg_rpe": summary["avg_rpe"],
+                    }
+                )
+            return result
 
         @self.app.get("/workouts/{workout_id}")
         def get_workout(workout_id: int):


### PR DESCRIPTION
## Summary
- extend `WorkoutRepository.fetch_all_workouts` to accept date range
- add `/workouts/history` endpoint returning workout summaries
- enhance Streamlit GUI with new **History** tab displaying previous workouts
- provide workout details dialog within GUI
- test the new REST endpoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877999dda2c83278bc20be2e0777f1f