### PR TITLE
Enhanced Streamlit UI and pyramid test data

### DIFF
--- a/db.py
+++ b/db.py
@@ -1075,10 +1075,18 @@ class ExerciseCatalogRepository(BaseRepository):
             )
         return None
 
-    def fetch_all_records(self) -> List[Tuple[str, str, str, str, str, str, str, int]]:
-        rows = self.fetch_all(
-            "SELECT name, muscle_group, variants, equipment_names, primary_muscle, secondary_muscle, tertiary_muscle, other_muscles, is_custom FROM exercise_catalog ORDER BY name;"
+    def fetch_all_records(
+        self, custom_only: bool = False
+    ) -> List[Tuple[str, str, str, str, str, str, str, int]]:
+        query = (
+            "SELECT name, muscle_group, variants, equipment_names, primary_muscle, "
+            "secondary_muscle, tertiary_muscle, other_muscles, is_custom FROM "
+            "exercise_catalog"
         )
+        if custom_only:
+            query += " WHERE is_custom = 1"
+        query += " ORDER BY name;"
+        rows = self.fetch_all(query)
         result = []
         for (
             name,

--- a/rest_api.py
+++ b/rest_api.py
@@ -626,6 +626,49 @@ class GymAPI:
                 {"id": tid, "date": date, "weights": weights} for tid, date, weights in tests
             ]
 
+        @self.app.get("/pyramid_tests/full")
+        def list_pyramid_tests_full():
+            tests = self.pyramid_tests.fetch_full_with_weights(self.pyramid_entries)
+            result = []
+            for row in tests:
+                (
+                    tid,
+                    name,
+                    date,
+                    eq_name,
+                    start_w,
+                    failed_w,
+                    max_a,
+                    dur,
+                    rest,
+                    rpe_attempt,
+                    tod,
+                    sleep_h,
+                    stress,
+                    nutrition,
+                    weights,
+                ) = row
+                result.append(
+                    {
+                        "id": tid,
+                        "exercise_name": name,
+                        "date": date,
+                        "equipment_name": eq_name,
+                        "starting_weight": start_w,
+                        "failed_weight": failed_w,
+                        "max_achieved": max_a,
+                        "test_duration_minutes": dur,
+                        "rest_between_attempts": rest,
+                        "rpe_per_attempt": rpe_attempt,
+                        "time_of_day": tod,
+                        "sleep_hours": sleep_h,
+                        "stress_level": stress,
+                        "nutrition_quality": nutrition,
+                        "weights": weights,
+                    }
+                )
+            return result
+
         @self.app.get("/settings/general")
         def get_general_settings():
             return self.settings.all_settings()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -685,3 +685,43 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(history[0]["weights"], [120.0])
         self.assertEqual(history[1]["weights"], [100.0, 110.0])
 
+    def test_pyramid_tests_full(self) -> None:
+        resp = self.client.post(
+            "/pyramid_tests",
+            params={
+                "weights": "100|110",
+                "exercise_name": "Bench",
+                "equipment_name": "Olympic Barbell",
+                "starting_weight": 100.0,
+                "failed_weight": 115.0,
+                "max_achieved": 110.0,
+                "test_duration_minutes": 10,
+                "rest_between_attempts": "120s",
+                "rpe_per_attempt": "8|9",
+                "time_of_day": "morning",
+                "sleep_hours": 7.5,
+                "stress_level": 2,
+                "nutrition_quality": 4,
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        tid = resp.json()["id"]
+
+        resp = self.client.get("/pyramid_tests/full")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()[0]
+        self.assertEqual(data["id"], tid)
+        self.assertEqual(data["exercise_name"], "Bench")
+        self.assertEqual(data["equipment_name"], "Olympic Barbell")
+        self.assertEqual(data["weights"], [100.0, 110.0])
+        self.assertEqual(data["starting_weight"], 100.0)
+        self.assertEqual(data["failed_weight"], 115.0)
+        self.assertEqual(data["max_achieved"], 110.0)
+        self.assertEqual(data["test_duration_minutes"], 10)
+        self.assertEqual(data["rest_between_attempts"], "120s")
+        self.assertEqual(data["rpe_per_attempt"], "8|9")
+        self.assertEqual(data["time_of_day"], "morning")
+        self.assertAlmostEqual(data["sleep_hours"], 7.5)
+        self.assertEqual(data["stress_level"], 2)
+        self.assertEqual(data["nutrition_quality"], 4)
+


### PR DESCRIPTION
## Summary
- extend ExerciseCatalogRepository with `custom_only` filter
- expose `/pyramid_tests/full` endpoint for detailed test data
- greatly extend pyramid test GUI with advanced fields
- add custom exercise management tab to settings
- test new endpoint with detailed pyramid test data

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779b8e0e308327946c0537f0d258e3