### PR TITLE
Enhance streamlit GUI and settings

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -674,11 +674,17 @@ class GymAPI:
             return self.settings.all_settings()
 
         @self.app.post("/settings/general")
-        def update_general_settings(body_weight: float = None, months_active: float = None):
+        def update_general_settings(
+            body_weight: float = None,
+            months_active: float = None,
+            theme: str = None,
+        ):
             if body_weight is not None:
                 self.settings.set_float("body_weight", body_weight)
             if months_active is not None:
                 self.settings.set_float("months_active", months_active)
+            if theme is not None:
+                self.settings.set_text("theme", theme)
             return {"status": "updated"}
 
         @self.app.post("/settings/delete_all")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,12 +137,13 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get("/settings/general")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
-            resp.json(), {"body_weight": 80.0, "months_active": 1.0}
+            resp.json(),
+            {"body_weight": 80.0, "months_active": 1.0, "theme": "light"},
         )
 
         resp = self.client.post(
             "/settings/general",
-            params={"body_weight": 85.5, "months_active": 6.0},
+            params={"body_weight": 85.5, "months_active": 6.0, "theme": "dark"},
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"status": "updated"})
@@ -150,7 +151,8 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get("/settings/general")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
-            resp.json(), {"body_weight": 85.5, "months_active": 6.0}
+            resp.json(),
+            {"body_weight": 85.5, "months_active": 6.0, "theme": "dark"},
         )
 
     def test_plan_workflow(self) -> None:


### PR DESCRIPTION
## Summary
- add new theme option to database defaults
- extend `SettingsRepository` for text values
- support theme setting via REST API
- update streamlit app with theme handling and new Reports tab
- test new general settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ac3394c08327a3b8057b6528ad0e