### PR TITLE
Enhance stats interface with personal records

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -541,6 +541,18 @@ class GymAPI:
         ):
             return self.statistics.overview(start_date, end_date)
 
+        @self.app.get("/stats/personal_records")
+        def stats_personal_records(
+            exercise: str = None,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.personal_records(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/prediction/progress")
         def prediction_progress(
             exercise: str,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -196,6 +196,14 @@ class GymApp:
                         {"1RM": [p["est_1rm"] for p in prog]},
                         x=[p["date"] for p in prog],
                     )
+            records = self.stats.personal_records(
+                ex_choice if ex_choice else None,
+                start.isoformat(),
+                end.isoformat(),
+            )
+            if records:
+                with st.expander("Personal Records", expanded=False):
+                    st.table(records[:5])
 
     def run(self) -> None:
         st.title("Workout Logger")
@@ -898,11 +906,12 @@ class GymApp:
             start_str,
             end_str,
         )
-        over_tab, dist_tab, prog_tab = st.tabs(
+        over_tab, dist_tab, prog_tab, rec_tab = st.tabs(
             [
                 "Overview",
                 "Distributions",
                 "Progress",
+                "Records",
             ]
         )
         with over_tab:
@@ -945,6 +954,14 @@ class GymApp:
                         x=[p["date"] for p in prog],
                     )
                 self._progress_forecast_section(ex_choice)
+        with rec_tab:
+            records = self.stats.personal_records(
+                ex_choice if ex_choice else None,
+                start_str,
+                end_str,
+            )
+            if records:
+                st.table(records)
 
     def _progress_forecast_section(self, exercise: str) -> None:
         st.subheader("Progress Forecast")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -533,6 +533,19 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(overview["avg_rpe"], 8.5)
         self.assertEqual(overview["exercises"], 1)
 
+        resp = self.client.get(
+            "/stats/personal_records",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        records = resp.json()
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["exercise"], "Bench Press")
+        self.assertEqual(rec["reps"], 8)
+        self.assertAlmostEqual(rec["weight"], 110.0)
+        self.assertAlmostEqual(rec["est_1rm"], 139.3, places=1)
+
     def test_timestamps(self) -> None:
         resp = self.client.post("/workouts", params={"training_type": "strength"})
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- add `personal_records` method in `StatisticsService`
- expose `/stats/personal_records` endpoint
- show records in the dashboard and statistics tabs
- test new endpoint via API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877af2acd908327aaf8c02c8772774c