### PR TITLE
Enhance plan management

### DIFF
--- a/db.py
+++ b/db.py
@@ -695,6 +695,27 @@ class PlannedWorkoutRepository(BaseRepository):
             raise ValueError("planned workout not found")
         return rows[0]
 
+    def update_date(self, plan_id: int, date: str) -> None:
+        rows = super().fetch_all(
+            "SELECT id FROM planned_workouts WHERE id = ?;",
+            (plan_id,),
+        )
+        if not rows:
+            raise ValueError("planned workout not found")
+        self.execute(
+            "UPDATE planned_workouts SET date = ? WHERE id = ?;",
+            (date, plan_id),
+        )
+
+    def delete(self, plan_id: int) -> None:
+        rows = super().fetch_all(
+            "SELECT id FROM planned_workouts WHERE id = ?;",
+            (plan_id,),
+        )
+        if not rows:
+            raise ValueError("planned workout not found")
+        self.execute("DELETE FROM planned_workouts WHERE id = ?;", (plan_id,))
+
     def delete_all(self) -> None:
         self._delete_all("planned_workouts")
 

--- a/planner_service.py
+++ b/planner_service.py
@@ -45,3 +45,14 @@ class PlannerService:
                     planned_set_id=set_id,
                 )
         return workout_id
+
+    def duplicate_plan(self, plan_id: int, new_date: str) -> int:
+        _pid, _date = self.planned_workouts.fetch_detail(plan_id)
+        new_id = self.planned_workouts.create(new_date)
+        exercises = self.planned_exercises.fetch_for_workout(plan_id)
+        for ex_id, name, equipment in exercises:
+            new_ex_id = self.planned_exercises.add(new_id, name, equipment)
+            sets = self.planned_sets.fetch_for_exercise(ex_id)
+            for _sid, reps, weight, rpe in sets:
+                self.planned_sets.add(new_ex_id, reps, weight, rpe)
+        return new_id

--- a/rest_api.py
+++ b/rest_api.py
@@ -361,6 +361,30 @@ class GymAPI:
             plans = self.planned_workouts.fetch_all()
             return [{"id": pid, "date": date} for pid, date in plans]
 
+        @self.app.put("/planned_workouts/{plan_id}")
+        def update_planned_workout(plan_id: int, date: str):
+            try:
+                self.planned_workouts.update_date(plan_id, date)
+                return {"status": "updated"}
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
+        @self.app.delete("/planned_workouts/{plan_id}")
+        def delete_planned_workout(plan_id: int):
+            try:
+                self.planned_workouts.delete(plan_id)
+                return {"status": "deleted"}
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
+        @self.app.post("/planned_workouts/{plan_id}/duplicate")
+        def duplicate_planned_workout(plan_id: int, date: str):
+            try:
+                new_id = self.planner.duplicate_plan(plan_id, date)
+                return {"id": new_id}
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
         @self.app.post("/planned_workouts/{plan_id}/exercises")
         def add_planned_exercise(plan_id: int, name: str, equipment: str):
             if not equipment:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -578,6 +578,32 @@ class GymApp:
                         key="select_planned_workout",
                     )
                     st.session_state.selected_planned_workout = int(selected)
+                    for pid, pdate in plans:
+                        with st.expander(f"{pdate} (ID {pid})", expanded=False):
+                            edit_date = st.date_input(
+                                "New Date",
+                                datetime.date.fromisoformat(pdate),
+                                key=f"plan_edit_{pid}",
+                            )
+                            dup_date = st.date_input(
+                                "Duplicate To",
+                                datetime.date.fromisoformat(pdate),
+                                key=f"plan_dup_{pid}",
+                            )
+                            cols = st.columns(3)
+                            if cols[0].button("Save", key=f"save_plan_{pid}"):
+                                self.planned_workouts.update_date(
+                                    pid, edit_date.isoformat()
+                                )
+                                st.success("Updated")
+                            if cols[1].button("Duplicate", key=f"dup_plan_{pid}"):
+                                self.planner.duplicate_plan(
+                                    pid, dup_date.isoformat()
+                                )
+                                st.success("Duplicated")
+                            if cols[2].button("Delete", key=f"del_plan_{pid}"):
+                                self.planned_workouts.delete(pid)
+                                st.success("Deleted")
 
     def _planned_exercise_section(self) -> None:
         st.header("Planned Exercises")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -218,6 +218,31 @@ class APITestCase(unittest.TestCase):
             },
         )
 
+        new_date = (datetime.date.today() + datetime.timedelta(days=2)).isoformat()
+        resp = self.client.put(
+            "/planned_workouts/1",
+            params={"date": new_date},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "updated"})
+
+        dup_date = (datetime.date.today() + datetime.timedelta(days=3)).isoformat()
+        resp = self.client.post(
+            "/planned_workouts/1/duplicate",
+            params={"date": dup_date},
+        )
+        self.assertEqual(resp.status_code, 200)
+        dup_id = resp.json()["id"]
+        self.assertEqual(dup_id, 2)
+
+        resp = self.client.delete("/planned_workouts/1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "deleted"})
+
+        resp = self.client.get("/planned_workouts")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), [{"id": dup_id, "date": dup_date}])
+
     def test_equipment_endpoints(self) -> None:
         response = self.client.get("/equipment/types")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- extend `PlannedWorkoutRepository` with update and delete helpers
- allow duplicating planned workouts in `PlannerService`
- expose REST endpoints for updating, deleting and duplicating plans
- expand Plan tab GUI with edit, duplicate and delete actions
- test new plan management endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c2492f648327a02486bac760240a