### PR TITLE
Improve dashboard and add progress insights

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -583,6 +583,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/progress_insights")
+        def stats_progress_insights(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.progress_insights(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/prediction/progress")
         def prediction_progress(
             exercise: str,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -571,6 +571,30 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(rec["weight"], 110.0)
         self.assertAlmostEqual(rec["est_1rm"], 139.3, places=1)
 
+    def test_progress_insights(self) -> None:
+        self.client.post("/workouts")
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 10, "weight": 100.0, "rpe": 8},
+        )
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 8, "weight": 110.0, "rpe": 9},
+        )
+
+        resp = self.client.get(
+            "/stats/progress_insights",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["trend"], "insufficient_data")
+        self.assertIn("plateau_score", data)
+
     def test_timestamps(self) -> None:
         resp = self.client.post("/workouts", params={"training_type": "strength"})
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- expose new `/stats/progress_insights` endpoint
- compute trend analysis with plateau scores
- extend dashboard with equipment usage and top exercises
- add new Insights tab to Streamlit GUI
- test new API feature

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c660d3d08327bea219dfd6048cf3