### PR TITLE
Add gamification settings to Streamlit GUI

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1349,12 +1349,18 @@ class GymApp:
                 ["light", "dark"],
                 index=["light", "dark"].index(self.theme),
             )
+            game_enabled = st.checkbox(
+                "Enable Gamification",
+                value=self.gamification.is_enabled(),
+            )
+            st.metric("Total Points", self.gamification.total_points())
             if st.button("Save General Settings"):
                 self.settings_repo.set_float("body_weight", bw)
                 self.settings_repo.set_float("months_active", ma)
                 self.settings_repo.set_text("theme", theme_opt)
                 self.theme = theme_opt
                 self._apply_theme()
+                self.gamification.enable(game_enabled)
                 st.success("Settings saved")
 
         with eq_tab:


### PR DESCRIPTION
## Summary
- expose Gamification settings in the general settings tab
- display current total points

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877cfc2f0c4832786efc7f7fbcfac7f