### PR TITLE
Implement training type for planned workouts

### DIFF
--- a/planner_service.py
+++ b/planner_service.py
@@ -31,9 +31,9 @@ class PlannerService:
         self.gamification = gamification
 
     def create_workout_from_plan(self, plan_id: int) -> int:
-        _pid, date = self.planned_workouts.fetch_detail(plan_id)
+        _pid, date, t_type = self.planned_workouts.fetch_detail(plan_id)
         workout_id = self.workouts.create(
-            date, "strength"
+            date, t_type
         )
         exercises = self.planned_exercises.fetch_for_workout(plan_id)
         for ex_id, name, equipment in exercises:
@@ -52,8 +52,8 @@ class PlannerService:
         return workout_id
 
     def duplicate_plan(self, plan_id: int, new_date: str) -> int:
-        _pid, _date = self.planned_workouts.fetch_detail(plan_id)
-        new_id = self.planned_workouts.create(new_date)
+        _pid, _date, t_type = self.planned_workouts.fetch_detail(plan_id)
+        new_id = self.planned_workouts.create(new_date, t_type)
         exercises = self.planned_exercises.fetch_for_workout(plan_id)
         for ex_id, name, equipment in exercises:
             new_ex_id = self.planned_exercises.add(new_id, name, equipment)

--- a/rest_api.py
+++ b/rest_api.py
@@ -368,19 +368,29 @@ class GymAPI:
             ]
 
         @self.app.post("/planned_workouts")
-        def create_planned_workout(date: str):
-            plan_id = self.planned_workouts.create(date)
+        def create_planned_workout(date: str, training_type: str = "strength"):
+            plan_id = self.planned_workouts.create(date, training_type)
             return {"id": plan_id}
 
         @self.app.get("/planned_workouts")
         def list_planned_workouts():
             plans = self.planned_workouts.fetch_all()
-            return [{"id": pid, "date": date} for pid, date in plans]
+            return [
+                {"id": pid, "date": date, "training_type": t}
+                for pid, date, t in plans
+            ]
 
         @self.app.put("/planned_workouts/{plan_id}")
-        def update_planned_workout(plan_id: int, date: str):
+        def update_planned_workout(
+            plan_id: int,
+            date: str | None = None,
+            training_type: str | None = None,
+        ):
             try:
-                self.planned_workouts.update_date(plan_id, date)
+                if date is not None:
+                    self.planned_workouts.update_date(plan_id, date)
+                if training_type is not None:
+                    self.planned_workouts.set_training_type(plan_id, training_type)
                 return {"status": "updated"}
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -634,8 +634,16 @@ class GymApp:
                 plan_date = st.date_input(
                     "Plan Date", datetime.date.today(), key="plan_date"
                 )
+                training_options = ["strength", "hypertrophy", "highintensity"]
+                plan_type = st.selectbox(
+                    "Training Type",
+                    training_options,
+                    key="plan_type",
+                )
                 if st.button("New Planned Workout"):
-                    pid = self.planned_workouts.create(plan_date.isoformat())
+                    pid = self.planned_workouts.create(
+                        plan_date.isoformat(), plan_type
+                    )
                     st.session_state.selected_planned_workout = pid
             with st.expander("Existing Plans", expanded=True):
                 plans = self.planned_workouts.fetch_all()
@@ -648,12 +656,18 @@ class GymApp:
                         key="select_planned_workout",
                     )
                     st.session_state.selected_planned_workout = int(selected)
-                    for pid, pdate in plans:
+                    for pid, pdate, ptype in plans:
                         with st.expander(f"{pdate} (ID {pid})", expanded=False):
                             edit_date = st.date_input(
                                 "New Date",
                                 datetime.date.fromisoformat(pdate),
                                 key=f"plan_edit_{pid}",
+                            )
+                            type_choice = st.selectbox(
+                                "Type",
+                                training_options,
+                                index=training_options.index(ptype),
+                                key=f"plan_type_{pid}",
                             )
                             dup_date = st.date_input(
                                 "Duplicate To",
@@ -664,6 +678,9 @@ class GymApp:
                             if cols[0].button("Save", key=f"save_plan_{pid}"):
                                 self.planned_workouts.update_date(
                                     pid, edit_date.isoformat()
+                                )
+                                self.planned_workouts.set_training_type(
+                                    pid, type_choice
                                 )
                                 st.success("Updated")
                             if cols[1].button("Duplicate", key=f"dup_plan_{pid}"):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,7 +96,10 @@ class APITestCase(unittest.TestCase):
         plan_date = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
 
         self.client.post("/workouts")
-        self.client.post("/planned_workouts", params={"date": plan_date})
+        self.client.post(
+            "/planned_workouts",
+            params={"date": plan_date, "training_type": "strength"},
+        )
 
         response = self.client.post("/settings/delete_all", params={"confirmation": "Yes, I confirm"})
         self.assertEqual(response.status_code, 200)
@@ -111,7 +114,10 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(response.json(), [])
 
         self.client.post("/workouts")
-        self.client.post("/planned_workouts", params={"date": plan_date})
+        self.client.post(
+            "/planned_workouts",
+            params={"date": plan_date, "training_type": "strength"},
+        )
 
         response = self.client.post("/settings/delete_logged", params={"confirmation": "Yes, I confirm"})
         self.assertEqual(response.status_code, 200)
@@ -168,13 +174,19 @@ class APITestCase(unittest.TestCase):
     def test_plan_workflow(self) -> None:
         plan_date = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
 
-        response = self.client.post("/planned_workouts", params={"date": plan_date})
+        response = self.client.post(
+            "/planned_workouts",
+            params={"date": plan_date, "training_type": "hypertrophy"},
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"id": 1})
 
         response = self.client.get("/planned_workouts")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{"id": 1, "date": plan_date}])
+        self.assertEqual(
+            response.json(),
+            [{"id": 1, "date": plan_date, "training_type": "hypertrophy"}],
+        )
 
         response = self.client.post(
             "/planned_workouts/1/exercises",
@@ -193,7 +205,13 @@ class APITestCase(unittest.TestCase):
 
         response = self.client.get("/workouts")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [{"id": 1, "date": plan_date}])
+        self.assertEqual(
+            response.json(),
+            [{"id": 1, "date": plan_date}],
+        )
+        resp_detail = self.client.get("/workouts/1")
+        self.assertEqual(resp_detail.status_code, 200)
+        self.assertEqual(resp_detail.json()["training_type"], "hypertrophy")
 
         response = self.client.get("/workouts/1/exercises")
         self.assertEqual(response.status_code, 200)
@@ -231,7 +249,7 @@ class APITestCase(unittest.TestCase):
         new_date = (datetime.date.today() + datetime.timedelta(days=2)).isoformat()
         resp = self.client.put(
             "/planned_workouts/1",
-            params={"date": new_date},
+            params={"date": new_date, "training_type": "strength"},
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {"status": "updated"})
@@ -251,7 +269,10 @@ class APITestCase(unittest.TestCase):
 
         resp = self.client.get("/planned_workouts")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json(), [{"id": dup_id, "date": dup_date}])
+        self.assertEqual(
+            resp.json(),
+            [{"id": dup_id, "date": dup_date, "training_type": "strength"}],
+        )
 
     def test_equipment_endpoints(self) -> None:
         response = self.client.get("/equipment/types")


### PR DESCRIPTION
## Summary
- add `training_type` column to planned workouts
- expose training type in PlannedWorkoutRepository
- keep training type when creating or duplicating plans
- add REST API and Streamlit support for plan training type
- update tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877da8d5dd0832795e97ae67cf0fce4