### PR TITLE
Implement training stress analytics

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -619,6 +619,13 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/training_stress")
+        def stats_training_stress(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.training_stress(start_date, end_date)
+
         @self.app.get("/gamification")
         def gamification_status():
             return {


### PR DESCRIPTION
## Summary
- implement `training_stress` calculation in `StatisticsService`
- expose `/stats/training_stress` endpoint
- test new endpoint through REST API

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877de521f20832783a2ef21a78ad467