### PR TITLE
Add weekly load variability metric

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -626,6 +626,13 @@ class GymAPI:
         ):
             return self.statistics.training_stress(start_date, end_date)
 
+        @self.app.get("/stats/load_variability")
+        def stats_load_variability(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.weekly_load_variability(start_date, end_date)
+
         @self.app.get("/gamification")
         def gamification_status():
             return {

--- a/tools.py
+++ b/tools.py
@@ -845,6 +845,21 @@ class ExercisePrescription(MathTools):
         return float(np.mean(loads) / std) if std != 0 else 1.0
 
     @staticmethod
+    def _weekly_load_variability(weights: list[float], reps: list[int], times: list[float]) -> float:
+        if not weights:
+            return 0.0
+        vols: dict[int, float] = {}
+        for w, r, t in zip(weights, reps, times):
+            week = int(t // 7)
+            vols[week] = vols.get(week, 0.0) + w * r
+        if len(vols) < 2:
+            return 0.0
+        values = np.array(list(vols.values()))
+        mean = np.mean(values)
+        std = np.std(values)
+        return float(std / (mean + ExercisePrescription.EPSILON))
+
+    @staticmethod
     def _deload_trigger(
         perf_factor: float,
         rpe_scores: list[float],


### PR DESCRIPTION
## Summary
- introduce `_weekly_load_variability` algorithm in `tools.py`
- compute load variability stats in `StatisticsService`
- expose `/stats/load_variability` endpoint
- test the new endpoint and algorithm

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e20d739c8327b3587382c9b616ec