### PR TITLE
Add training stress balance metric

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -633,6 +633,13 @@ class GymAPI:
         ):
             return self.statistics.weekly_load_variability(start_date, end_date)
 
+        @self.app.get("/stats/stress_balance")
+        def stats_stress_balance(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.stress_balance(start_date, end_date)
+
         @self.app.get("/gamification")
         def gamification_status():
             return {

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1021,12 +1021,13 @@ class GymApp:
             start_str,
             end_str,
         )
-        over_tab, dist_tab, prog_tab, rec_tab = st.tabs(
+        over_tab, dist_tab, prog_tab, rec_tab, tsb_tab = st.tabs(
             [
                 "Overview",
                 "Distributions",
                 "Progress",
                 "Records",
+                "Stress Balance",
             ]
         )
         with over_tab:
@@ -1077,6 +1078,10 @@ class GymApp:
             )
             if records:
                 st.table(records)
+        with tsb_tab:
+            tsb = self.stats.stress_balance(start_str, end_str)
+            if tsb:
+                st.line_chart({"TSB": [d["tsb"] for d in tsb]}, x=[d["date"] for d in tsb])
 
     def _progress_forecast_section(self, exercise: str) -> None:
         st.subheader("Progress Forecast")


### PR DESCRIPTION
## Summary
- implement training stress balance calculations
- expose stress balance via REST API
- show stress balance in the Streamlit stats tab
- cover stress balance with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e433facc83278bc90fc71f26e259