### PR TITLE
Add volume forecast functionality

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -650,6 +650,14 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/volume_forecast")
+        def stats_volume_forecast(
+            days: int = 7,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.volume_forecast(days, start_date, end_date)
+
         @self.app.get("/gamification")
         def gamification_status():
             return {

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1074,6 +1074,7 @@ class GymApp:
                         x=[p["date"] for p in prog],
                     )
                 self._progress_forecast_section(ex_choice)
+            self._volume_forecast_section(start_str, end_str)
         with rec_tab:
             records = self.stats.personal_records(
                 ex_choice if ex_choice else None,
@@ -1097,6 +1098,17 @@ class GymApp:
                 st.line_chart(
                     {"Est 1RM": [f["est_1rm"] for f in forecast]},
                     x=[str(f["week"]) for f in forecast],
+                )
+
+    def _volume_forecast_section(self, start: str, end: str) -> None:
+        st.subheader("Volume Forecast")
+        days = st.slider("Days", 1, 14, 7, key="vol_forecast_days")
+        if st.button("Show Volume Forecast"):
+            data = self.stats.volume_forecast(days, start, end)
+            if data:
+                st.line_chart(
+                    {"Volume": [d["volume"] for d in data]},
+                    x=[d["date"] for d in data],
                 )
 
     def _insights_tab(self) -> None:


### PR DESCRIPTION
## Summary
- implement `volume_forecast` calculations in `StatisticsService`
- expose new `/stats/volume_forecast` endpoint
- display volume forecast in Streamlit statistics tab
- test coverage for new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877eaeb8b688327a4d5271f422389d3