### PR TITLE
Add deload recommendation metrics

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -682,6 +682,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/deload_recommendation")
+        def stats_deload_recommendation(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.deload_recommendation(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/prediction/progress")
         def prediction_progress(
             exercise: str,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1066,3 +1066,25 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(data[0]["volume"], expected[0], places=2)
         self.assertAlmostEqual(data[1]["volume"], expected[1], places=2)
 
+    def test_deload_recommendation_endpoint(self) -> None:
+        self.client.post("/workouts")
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 9},
+        )
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 9},
+        )
+
+        resp = self.client.get(
+            "/stats/deload_recommendation",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"trigger": 0.33, "score": 0.14})
+


### PR DESCRIPTION
## Summary
- compute deload trigger and score
- expose REST API endpoint for deload metrics
- test the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877edd3c2d883278347f040ac089c1e