### PR TITLE
Add stress overview metric

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -640,6 +640,13 @@ class GymAPI:
         ):
             return self.statistics.stress_balance(start_date, end_date)
 
+        @self.app.get("/stats/stress_overview")
+        def stats_stress_overview(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.stress_overview(start_date, end_date)
+
         @self.app.get("/stats/session_efficiency")
         def stats_session_efficiency(
             start_date: str = None,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1087,6 +1087,10 @@ class GymApp:
             tsb = self.stats.stress_balance(start_str, end_str)
             if tsb:
                 st.line_chart({"TSB": [d["tsb"] for d in tsb]}, x=[d["date"] for d in tsb])
+            overview = self.stats.stress_overview(start_str, end_str)
+            if overview:
+                st.metric("Stress", overview["stress"])
+                st.metric("Fatigue", overview["fatigue"])
 
     def _progress_forecast_section(self, exercise: str) -> None:
         st.subheader("Progress Forecast")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1003,6 +1003,40 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(data[0]["tsb"], 0.0)
         self.assertEqual(data[1]["tsb"], 0.0)
 
+    def test_stress_overview_endpoint(self) -> None:
+        d1 = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+        d2 = datetime.date.today().isoformat()
+
+        self.client.post("/workouts", params={"date": d1})
+        self.client.post("/workouts", params={"date": d2})
+
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/workouts/2/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 8},
+        )
+        self.client.post(
+            "/exercises/2/sets",
+            params={"reps": 5, "weight": 110.0, "rpe": 8},
+        )
+
+        resp = self.client.get(
+            "/stats/stress_overview",
+            params={"start_date": d1, "end_date": d2},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertAlmostEqual(data["stress"], 2.0, places=2)
+        self.assertAlmostEqual(data["fatigue"], 1.78, places=2)
+
     def test_session_efficiency_endpoint(self) -> None:
         self.client.post("/workouts")
         self.client.post(


### PR DESCRIPTION
## Summary
- implement stress_overview calculation in stats_service
- expose new /stats/stress_overview endpoint
- show stress and fatigue in Streamlit Stress Balance tab
- cover the new endpoint in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f0573c048327b6c30216790ea214