### PR TITLE
Enhance gamification stats in GUI

### DIFF
--- a/db.py
+++ b/db.py
@@ -1445,3 +1445,10 @@ class GamificationRepository(BaseRepository):
         rows = self.fetch_all("SELECT SUM(points) FROM gamification_points;")
         return float(rows[0][0] or 0.0)
 
+    def workout_totals(self) -> List[Tuple[int, float]]:
+        rows = self.fetch_all(
+            "SELECT workout_id, SUM(points) FROM gamification_points "
+            "GROUP BY workout_id ORDER BY workout_id;"
+        )
+        return [(int(wid), float(pts or 0.0)) for wid, pts in rows]
+

--- a/gamification_service.py
+++ b/gamification_service.py
@@ -25,6 +25,9 @@ class GamificationService:
     def total_points(self) -> float:
         return self.repo.total_points()
 
+    def points_by_workout(self) -> list[tuple[int, float]]:
+        return self.repo.workout_totals()
+
     def record_set(self, exercise_id: int, reps: int, weight: float, rpe: int) -> None:
         if not self.is_enabled():
             return

--- a/rest_api.py
+++ b/rest_api.py
@@ -677,6 +677,13 @@ class GymAPI:
             self.gamification.enable(enabled)
             return {"status": "updated"}
 
+        @self.app.get("/gamification/workout_points")
+        def gamification_workout_points():
+            return [
+                {"workout_id": wid, "points": pts}
+                for wid, pts in self.gamification.points_by_workout()
+            ]
+
         @self.app.get("/stats/progress_insights")
         def stats_progress_insights(
             exercise: str,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -264,12 +264,13 @@ class GymApp:
         with history_tab:
             self._history_tab()
         with stats_tab:
-            dash_sub, stats_sub, insights_sub, rep_sub = st.tabs(
+            dash_sub, stats_sub, insights_sub, rep_sub, game_sub = st.tabs(
                 [
                     "Dashboard",
                     "Exercise Stats",
                     "Insights",
                     "Reports",
+                    "Gamification",
                 ]
             )
             with dash_sub:
@@ -280,6 +281,8 @@ class GymApp:
                 self._insights_tab()
             with rep_sub:
                 self._reports_tab()
+            with game_sub:
+                self._gamification_tab()
         with tests_tab:
             self._tests_tab()
         with settings_tab:
@@ -1220,6 +1223,18 @@ class GymApp:
                 st.line_chart(
                     {"Volume": [d["volume"] for d in daily]},
                     x=[d["date"] for d in daily],
+                )
+
+    def _gamification_tab(self) -> None:
+        st.header("Gamification Stats")
+        with st.expander("Summary", expanded=True):
+            st.metric("Total Points", self.gamification.total_points())
+        with st.expander("Points by Workout", expanded=True):
+            data = self.gamification.points_by_workout()
+            if data:
+                st.bar_chart(
+                    {"Points": [p[1] for p in data]},
+                    x=[str(p[0]) for p in data],
                 )
 
     def _tests_tab(self) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -461,6 +461,13 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertAlmostEqual(resp.json()["points"], 101.31, places=2)
 
+        resp = self.client.get("/gamification/workout_points")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["workout_id"], 1)
+        self.assertAlmostEqual(data[0]["points"], 101.31, places=2)
+
         resp = self.client.get("/exercise_catalog/Barbell Bench Press")
         self.assertEqual(resp.status_code, 200)
         data = resp.json()


### PR DESCRIPTION
## Summary
- extend `GamificationRepository` with `workout_totals`
- add `points_by_workout` to `GamificationService`
- expose `/gamification/workout_points` endpoint
- show gamification stats in new statistics subtab
- test gamification totals via REST API

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f59668c0832780e9d634658be31f