### PR TITLE
Add readiness score calculations

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -672,6 +672,13 @@ class GymAPI:
         ):
             return self.statistics.overtraining_risk(start_date, end_date)
 
+        @self.app.get("/stats/readiness")
+        def stats_readiness(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.readiness(start_date, end_date)
+
         @self.app.get("/gamification")
         def gamification_status():
             return {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -98,6 +98,11 @@ class MathToolsTestCase(unittest.TestCase):
         stress = ExercisePrescription._stress_level([100, 110], [5, 5], [8, 8], [0, 1], 120.0, 10)
         self.assertAlmostEqual(stress, 2.0)
 
+    def test_readiness_score(self) -> None:
+        val = MathTools.readiness_score(2.0, 3.0)
+        expected = MathTools.clamp(10.0 - math.sqrt(2.0**2 + 3.0**2), 0.0, 10.0)
+        self.assertAlmostEqual(val, expected)
+
     def test_periodization_and_velocity_loss(self) -> None:
         factor = ExercisePrescription._adaptive_periodization_factor([1.0, 1.1, 1.2, 1.3], 2)
         self.assertAlmostEqual(factor, 0.9)

--- a/tools.py
+++ b/tools.py
@@ -89,6 +89,12 @@ class MathTools:
         base = (stress + fatigue) / 2.0
         return MathTools.clamp(base * (1 + variability), 0.0, 10.0)
 
+    @staticmethod
+    def readiness_score(stress: float, fatigue: float) -> float:
+        """Return a training readiness score from stress and fatigue."""
+        score = 10.0 - math.sqrt(stress**2 + fatigue**2)
+        return MathTools.clamp(score, 0.0, 10.0)
+
 
 class ExercisePrescription(MathTools):
     """Advanced utilities for generating detailed workout prescriptions."""


### PR DESCRIPTION
## Summary
- add `MathTools.readiness_score`
- compute readiness metrics in statistics service
- expose `/stats/readiness` endpoint
- test new readiness API and score calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f8a94bc4832793c36b28c1e133bb