### PR TITLE
Add training monotony stats

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -633,6 +633,13 @@ class GymAPI:
         ):
             return self.statistics.weekly_load_variability(start_date, end_date)
 
+        @self.app.get("/stats/training_monotony")
+        def stats_training_monotony(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.training_monotony(start_date, end_date)
+
         @self.app.get("/stats/stress_balance")
         def stats_stress_balance(
             start_date: str = None,

--- a/stats_service.py
+++ b/stats_service.py
@@ -518,6 +518,26 @@ class StatisticsService:
             "volumes": volumes,
         }
 
+    def training_monotony(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> Dict[str, float]:
+        """Return training monotony value across the specified dates."""
+        names = self.exercise_names.fetch_all()
+        rows = self.sets.fetch_history_by_names(
+            names,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        if not rows:
+            return {"monotony": 1.0}
+
+        weights = [float(r[1]) for r in rows]
+        reps = [int(r[0]) for r in rows]
+        val = ExercisePrescription._weekly_monotony(weights, reps)
+        return {"monotony": round(val, 2)}
+
     def stress_balance(
         self,
         start_date: Optional[str] = None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -975,6 +975,39 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(data["variability"], 0.2, places=2)
         self.assertEqual(len(data["weeks"]), 2)
 
+    def test_training_monotony_endpoint(self) -> None:
+        d1 = (datetime.date.today() - datetime.timedelta(days=7)).isoformat()
+        d2 = datetime.date.today().isoformat()
+
+        self.client.post("/workouts", params={"date": d1})
+        self.client.post("/workouts", params={"date": d2})
+
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/workouts/2/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 10, "weight": 100.0, "rpe": 8},
+        )
+        self.client.post(
+            "/exercises/2/sets",
+            params={"reps": 10, "weight": 150.0, "rpe": 8},
+        )
+
+        resp = self.client.get(
+            "/stats/training_monotony",
+            params={"start_date": d1, "end_date": d2},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertAlmostEqual(data["monotony"], 5.0, places=2)
+
     def test_stress_balance_endpoint(self) -> None:
         d1 = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
         d2 = datetime.date.today().isoformat()


### PR DESCRIPTION
## Summary
- extend `StatisticsService` with `training_monotony` calculation
- expose `/stats/training_monotony` REST endpoint
- test new endpoint via `APITestCase`

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6877fa57365883279aef565779edfac6