### PR TITLE
Add performance momentum statistic

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -729,6 +729,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/performance_momentum")
+        def stats_performance_momentum(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.performance_momentum(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/prediction/progress")
         def prediction_progress(
             exercise: str,


### PR DESCRIPTION
## Summary
- extend StatsService with `performance_momentum` calculation
- expose new `/stats/performance_momentum` REST endpoint
- cover new logic with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fcc4943c8327abed26b69189c8e3