### PR TITLE
Add advanced plateau score endpoint

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -724,6 +724,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/advanced_plateau")
+        def stats_advanced_plateau(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.plateau_score(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/stats/deload_recommendation")
         def stats_deload_recommendation(
             exercise: str,


### PR DESCRIPTION
## Summary
- implement plateau_score in `StatisticsService`
- expose `/stats/advanced_plateau` in REST API
- test plateau endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687800b7ffc08327b381aeadf557fbab