### PR TITLE
Add warmup weight calculator

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -20,7 +20,7 @@ from planner_service import PlannerService
 from recommendation_service import RecommendationService
 from stats_service import StatisticsService
 from gamification_service import GamificationService
-from tools import ExercisePrescription
+from tools import ExercisePrescription, MathTools
 
 
 class GymAPI:
@@ -711,6 +711,14 @@ class GymAPI:
                 {"workout_id": wid, "points": pts}
                 for wid, pts in self.gamification.points_by_workout()
             ]
+
+        @self.app.get("/utils/warmup_weights")
+        def utils_warmup_weights(target_weight: float, sets: int = 3):
+            try:
+                weights = MathTools.warmup_weights(target_weight, sets)
+                return {"weights": weights}
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
 
         @self.app.get("/stats/progress_insights")
         def stats_progress_insights(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -21,6 +21,7 @@ from planner_service import PlannerService
 from recommendation_service import RecommendationService
 from stats_service import StatisticsService
 from gamification_service import GamificationService
+from tools import MathTools
 
 
 class GymApp:
@@ -1363,6 +1364,25 @@ class GymApp:
                     for _tid, d, ws in history
                 ]
                 st.table(display)
+
+        with st.expander("Warmup Calculator", expanded=False):
+            tgt = st.number_input(
+                "Target Weight (kg)", min_value=0.0, step=0.5, key="warmup_target"
+            )
+            count = st.number_input(
+                "Warmup Sets", min_value=1, step=1, value=3, key="warmup_sets"
+            )
+            if st.button("Calculate Warmup", key="warmup_calc"):
+                try:
+                    weights = MathTools.warmup_weights(float(tgt), int(count))
+                    st.table(
+                        [
+                            {"set": i + 1, "weight": w}
+                            for i, w in enumerate(weights)
+                        ]
+                    )
+                except ValueError as e:
+                    st.warning(str(e))
 
     def _settings_tab(self) -> None:
         st.header("Settings")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1339,3 +1339,11 @@ class APITestCase(unittest.TestCase):
         )
         self.assertAlmostEqual(data["score"], round(expected, 2), places=2)
 
+    def test_warmup_weights_endpoint(self) -> None:
+        resp = self.client.get(
+            "/utils/warmup_weights",
+            params={"target_weight": 100.0, "sets": 3},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"weights": [30.0, 60.0, 90.0]})
+

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -54,6 +54,12 @@ class MathToolsTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             MathTools.required_progression(150.0, 120.0, 0)
 
+    def test_warmup_weights(self) -> None:
+        weights = MathTools.warmup_weights(100.0, 3)
+        self.assertEqual(weights, [30.0, 60.0, 90.0])
+        with self.assertRaises(ValueError):
+            MathTools.warmup_weights(-1.0, 3)
+
     def test_sleep_recovery_index(self) -> None:
         sf = ExercisePrescription._sleep_factor(7)
         psqf = ExercisePrescription._perceived_sleep_quality_factor(4)

--- a/tools.py
+++ b/tools.py
@@ -73,6 +73,14 @@ class MathTools:
         return (target_1rm - current_1rm) / days_remaining
 
     @staticmethod
+    def warmup_weights(target_weight: float, sets: int) -> list[float]:
+        """Return a list of warm-up weights leading up to ``target_weight``."""
+        if target_weight <= 0 or sets <= 0:
+            raise ValueError("invalid input values")
+        inc = np.linspace(0.3, 0.9, sets)
+        return [round(target_weight * float(i), 2) for i in inc]
+
+    @staticmethod
     def session_efficiency(
         volume: float, duration_seconds: float, avg_rpe: float | None = None
     ) -> float:


### PR DESCRIPTION
## Summary
- add `warmup_weights` helper in MathTools
- expose `/utils/warmup_weights` endpoint in REST API
- display a Warmup Calculator in the Tests tab
- test new helper and endpoint

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68780271aab883278c00f9db56c2d717