### PR TITLE
Add online ML model integration

### DIFF
--- a/ml_service.py
+++ b/ml_service.py
@@ -1,0 +1,58 @@
+import io
+import torch
+from db import MLModelRepository, ExerciseNameRepository
+
+class RPEModel(torch.nn.Module):
+    """Simple model storing a single RPE value."""
+
+    def __init__(self, initial: float = 7.0) -> None:
+        super().__init__()
+        self.value = torch.nn.Parameter(torch.tensor(float(initial)))
+
+    def forward(self) -> torch.Tensor:  # pragma: no cover - simple pass
+        return self.value
+
+
+class PerformanceModelService:
+    """Handle online training and prediction of RPE values."""
+
+    def __init__(
+        self,
+        repo: MLModelRepository,
+        name_repo: ExerciseNameRepository,
+        lr: float = 0.1,
+    ) -> None:
+        self.repo = repo
+        self.names = name_repo
+        self.lr = lr
+        self.models: dict[str, tuple[RPEModel, torch.optim.Optimizer]] = {}
+
+    def _get(self, name: str) -> tuple[RPEModel, torch.optim.Optimizer]:
+        canonical = self.names.canonical(name)
+        if canonical not in self.models:
+            blob = self.repo.load(canonical)
+            model = RPEModel()
+            opt = torch.optim.SGD(model.parameters(), lr=self.lr)
+            if blob is not None:
+                buffer = io.BytesIO(blob)
+                state = torch.load(buffer)
+                model.load_state_dict(state)
+            self.models[canonical] = (model, opt)
+        return self.models[canonical]
+
+    def train(self, name: str, rpe: float) -> None:
+        model, opt = self._get(name)
+        opt.zero_grad()
+        pred = model()
+        target = torch.tensor([rpe], dtype=torch.float32)
+        loss = torch.nn.functional.mse_loss(pred, target)
+        loss.backward()
+        opt.step()
+        buf = io.BytesIO()
+        torch.save(model.state_dict(), buf)
+        self.repo.save(self.names.canonical(name), buf.getvalue())
+
+    def predict(self, name: str) -> float:
+        model, _ = self._get(name)
+        with torch.no_grad():
+            return float(model().item())

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas
 statsmodels
 pywavelets
 scikit-learn
+torch

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -16,11 +16,13 @@ from db import (
     PyramidTestRepository,
     PyramidEntryRepository,
     GamificationRepository,
+    MLModelRepository,
 )
 from planner_service import PlannerService
 from recommendation_service import RecommendationService
 from stats_service import StatisticsService
 from gamification_service import GamificationService
+from ml_service import PerformanceModelService
 from tools import MathTools
 
 
@@ -46,10 +48,15 @@ class GymApp:
         self.pyramid_tests = PyramidTestRepository()
         self.pyramid_entries = PyramidEntryRepository()
         self.game_repo = GamificationRepository()
+        self.ml_models = MLModelRepository()
         self.gamification = GamificationService(
             self.game_repo,
             self.exercises,
             self.settings_repo,
+        )
+        self.ml_service = PerformanceModelService(
+            self.ml_models,
+            self.exercise_names_repo,
         )
         self.planner = PlannerService(
             self.workouts,
@@ -67,6 +74,7 @@ class GymApp:
             self.exercise_names_repo,
             self.settings_repo,
             self.gamification,
+            self.ml_service,
         )
         self.stats = StatisticsService(
             self.sets,


### PR DESCRIPTION
## Summary
- introduce torch-based performance model for RPE prediction
- train models incrementally whenever sets are logged or updated
- store model states in new `ml_models` table
- blend ML predictions into recommendation service
- test persistent training with new ML integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878234397448327a8f8e1e718eea378