### PR TITLE
Add torch progress model with deterministic training

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -25,6 +25,7 @@ from ml_service import (
     PerformanceModelService,
     VolumeModelService,
     ReadinessModelService,
+    ProgressModelService,
 )
 from tools import ExercisePrescription, MathTools
 
@@ -59,6 +60,7 @@ class GymAPI:
         )
         self.volume_model = VolumeModelService(self.ml_models)
         self.readiness_model = ReadinessModelService(self.ml_models)
+        self.progress_model = ProgressModelService(self.ml_models)
         self.planner = PlannerService(
             self.workouts,
             self.exercises,
@@ -83,6 +85,7 @@ class GymAPI:
             self.settings,
             self.volume_model,
             self.readiness_model,
+            self.progress_model,
         )
         self.app = FastAPI()
         self._setup_routes()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,7 +22,12 @@ from planner_service import PlannerService
 from recommendation_service import RecommendationService
 from stats_service import StatisticsService
 from gamification_service import GamificationService
-from ml_service import PerformanceModelService, VolumeModelService, ReadinessModelService
+from ml_service import (
+    PerformanceModelService,
+    VolumeModelService,
+    ReadinessModelService,
+    ProgressModelService,
+)
 from tools import MathTools
 
 
@@ -60,6 +65,7 @@ class GymApp:
         )
         self.volume_model = VolumeModelService(self.ml_models)
         self.readiness_model = ReadinessModelService(self.ml_models)
+        self.progress_model = ProgressModelService(self.ml_models)
         self.planner = PlannerService(
             self.workouts,
             self.exercises,
@@ -84,6 +90,7 @@ class GymApp:
             self.settings_repo,
             self.volume_model,
             self.readiness_model,
+            self.progress_model,
         )
         self._state_init()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -652,8 +652,8 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         forecast = resp.json()
         self.assertEqual(len(forecast), 2)
-        self.assertAlmostEqual(forecast[0]["est_1rm"], 139.3, places=1)
-        self.assertAlmostEqual(forecast[1]["est_1rm"], 139.3, places=1)
+        self.assertAlmostEqual(forecast[0]["est_1rm"], 123.33, places=2)
+        self.assertAlmostEqual(forecast[1]["est_1rm"], 123.32, places=2)
 
         resp = self.client.get("/stats/overview")
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- add `ProgressModelService` for predicting 1RM progression
- initialize torch models deterministically
- integrate progress model into statistics service and API
- update Streamlit app to use progress model
- adjust unit tests for new forecast values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687879d5546083279fefce7bd6f85415