### PR TITLE
Add YAML sync for settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,20 @@
+import os
+import yaml
+
+
+class YamlConfig:
+    """Load and save settings to a YAML file."""
+
+    def __init__(self, path: str = "settings.yaml") -> None:
+        self.path = path
+
+    def load(self) -> dict:
+        if not os.path.exists(self.path):
+            return {}
+        with open(self.path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return data or {}
+
+    def save(self, data: dict) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ statsmodels
 pywavelets
 scikit-learn
 torch
+pyyaml

--- a/rest_api.py
+++ b/rest_api.py
@@ -33,7 +33,7 @@ from tools import ExercisePrescription, MathTools
 class GymAPI:
     """Provides REST endpoints for workout logging."""
 
-    def __init__(self, db_path: str = "workout.db") -> None:
+    def __init__(self, db_path: str = "workout.db", yaml_path: str = "settings.yaml") -> None:
         self.workouts = WorkoutRepository(db_path)
         self.exercises = ExerciseRepository(db_path)
         self.sets = SetRepository(db_path)
@@ -44,7 +44,7 @@ class GymAPI:
         self.exercise_catalog = ExerciseCatalogRepository(db_path)
         self.muscles = MuscleRepository(db_path)
         self.exercise_names = ExerciseNameRepository(db_path)
-        self.settings = SettingsRepository(db_path)
+        self.settings = SettingsRepository(db_path, yaml_path)
         self.pyramid_tests = PyramidTestRepository(db_path)
         self.pyramid_entries = PyramidEntryRepository(db_path)
         self.game_repo = GamificationRepository(db_path)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -34,8 +34,8 @@ from tools import MathTools
 class GymApp:
     """Streamlit application for workout logging."""
 
-    def __init__(self) -> None:
-        self.settings_repo = SettingsRepository()
+    def __init__(self, yaml_path: str = "settings.yaml") -> None:
+        self.settings_repo = SettingsRepository(yaml_path=yaml_path)
         self.theme = self.settings_repo.get_text("theme", "light")
         self._configure_page()
         self._inject_responsive_css()

--- a/tests/test_longterm_usage.py
+++ b/tests/test_longterm_usage.py
@@ -13,14 +13,19 @@ from tools import MathTools
 class LongTermUsageTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.db_path = "test_longterm.db"
+        self.yaml_path = "test_longterm_settings.yaml"
         if os.path.exists(self.db_path):
             os.remove(self.db_path)
-        self.api = GymAPI(db_path=self.db_path)
+        if os.path.exists(self.yaml_path):
+            os.remove(self.yaml_path)
+        self.api = GymAPI(db_path=self.db_path, yaml_path=self.yaml_path)
         self.client = TestClient(self.api.app)
 
     def tearDown(self) -> None:
         if os.path.exists(self.db_path):
             os.remove(self.db_path)
+        if os.path.exists(self.yaml_path):
+            os.remove(self.yaml_path)
 
     def test_partial_long_term_usage(self) -> None:
         start = datetime.date.today() - datetime.timedelta(days=27)
@@ -247,14 +252,19 @@ if __name__ == "__main__":
 class ExtendedUsageTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.db_path = "test_longterm_ext.db"
+        self.yaml_path = "test_longterm_ext_settings.yaml"
         if os.path.exists(self.db_path):
             os.remove(self.db_path)
-        self.api = GymAPI(db_path=self.db_path)
+        if os.path.exists(self.yaml_path):
+            os.remove(self.yaml_path)
+        self.api = GymAPI(db_path=self.db_path, yaml_path=self.yaml_path)
         self.client = TestClient(self.api.app)
 
     def tearDown(self) -> None:
         if os.path.exists(self.db_path):
             os.remove(self.db_path)
+        if os.path.exists(self.yaml_path):
+            os.remove(self.yaml_path)
 
     def test_extended_long_term_usage(self) -> None:
         start = datetime.date.today() - datetime.timedelta(days=55)


### PR DESCRIPTION
## Summary
- implement `YamlConfig` to read/write settings YAML
- sync YAML with DB in `SettingsRepository`
- allow REST API and Streamlit app to specify YAML path
- track YAML sync in tests
- install `pyyaml` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68788a0b2cf88327a057d9efb76a3717