### PR TITLE
Enhance ML models with RL and injury risk analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Create aliases for muscles and exercise names so queries treat them as the same entry.
 - Extensive statistics including daily volume, progression forecasts, stress metrics, readiness scores and personal records.
 - Optional gamification awarding points for completed sets.
-- Machine learning models for RPE, volume, readiness and progress predictions. Training and prediction can be toggled in the settings.
+- Machine learning models for RPE, volume, readiness and progress predictions. Training and prediction can be toggled in the settings. Reinforcement learning dynamically adjusts exercise goals and an LSTM model tracks long‑term adaptation. Injury risk analytics provide preventive insights.
 - Utilities such as pyramid strength tests and warm‑up weight suggestions.
 - All settings can be changed in the UI or by editing `settings.yaml` and remain synchronized.
 - Calculate average rest times between sets via `/stats/rest_times`.

--- a/db.py
+++ b/db.py
@@ -391,6 +391,10 @@ class Database:
             "ml_readiness_prediction_enabled": "1",
             "ml_progress_training_enabled": "1",
             "ml_progress_prediction_enabled": "1",
+            "ml_goal_training_enabled": "1",
+            "ml_goal_prediction_enabled": "1",
+            "ml_injury_training_enabled": "1",
+            "ml_injury_prediction_enabled": "1",
         }
         with self._connection() as conn:
             for key, value in defaults.items():
@@ -965,6 +969,10 @@ class SettingsRepository(BaseRepository):
             "ml_readiness_prediction_enabled",
             "ml_progress_training_enabled",
             "ml_progress_prediction_enabled",
+            "ml_goal_training_enabled",
+            "ml_goal_prediction_enabled",
+            "ml_injury_training_enabled",
+            "ml_injury_prediction_enabled",
         }
         for k, v in rows:
             if k in bool_keys:
@@ -994,6 +1002,10 @@ class SettingsRepository(BaseRepository):
                 "ml_readiness_prediction_enabled",
                 "ml_progress_training_enabled",
                 "ml_progress_prediction_enabled",
+                "ml_goal_training_enabled",
+                "ml_goal_prediction_enabled",
+                "ml_injury_training_enabled",
+                "ml_injury_prediction_enabled",
             }
             for key, value in data.items():
                 val = str(value)
@@ -1059,6 +1071,10 @@ class SettingsRepository(BaseRepository):
             "ml_readiness_prediction_enabled",
             "ml_progress_training_enabled",
             "ml_progress_prediction_enabled",
+            "ml_goal_training_enabled",
+            "ml_goal_prediction_enabled",
+            "ml_injury_training_enabled",
+            "ml_injury_prediction_enabled",
         }
         for k in bool_keys:
             if k in data:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1513,6 +1513,22 @@ class GymApp:
                 "Progress Model Prediction",
                 value=self.settings_repo.get_bool("ml_progress_prediction_enabled", True),
             )
+            goal_train = st.checkbox(
+                "Goal Model Training",
+                value=self.settings_repo.get_bool("ml_goal_training_enabled", True),
+            )
+            goal_pred = st.checkbox(
+                "Goal Model Prediction",
+                value=self.settings_repo.get_bool("ml_goal_prediction_enabled", True),
+            )
+            inj_train = st.checkbox(
+                "Injury Model Training",
+                value=self.settings_repo.get_bool("ml_injury_training_enabled", True),
+            )
+            inj_pred = st.checkbox(
+                "Injury Model Prediction",
+                value=self.settings_repo.get_bool("ml_injury_prediction_enabled", True),
+            )
             st.metric("Total Points", self.gamification.total_points())
             if st.button("Save General Settings"):
                 self.settings_repo.set_float("body_weight", bw)
@@ -1532,6 +1548,10 @@ class GymApp:
                 self.settings_repo.set_bool("ml_readiness_prediction_enabled", read_pred)
                 self.settings_repo.set_bool("ml_progress_training_enabled", prog_train)
                 self.settings_repo.set_bool("ml_progress_prediction_enabled", prog_pred)
+                self.settings_repo.set_bool("ml_goal_training_enabled", goal_train)
+                self.settings_repo.set_bool("ml_goal_prediction_enabled", goal_pred)
+                self.settings_repo.set_bool("ml_injury_training_enabled", inj_train)
+                self.settings_repo.set_bool("ml_injury_prediction_enabled", inj_pred)
                 st.success("Settings saved")
 
         with eq_tab:


### PR DESCRIPTION
## Summary
- add reinforcement learning goal setting model and injury risk model
- upgrade progress model to LSTM
- expose injury risk via `/stats/injury_risk`
- integrate new models with API, recommendations and settings
- update Streamlit settings UI for new ML toggles
- adjust tests for variable ML predictions and add injury risk test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b0cb81e88327bd51e1ab48da52f3