### PR TITLE
Add body weight tracking feature

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -18,6 +18,7 @@ from db import (
     GamificationRepository,
     MLModelRepository,
     MLLogRepository,
+    BodyWeightRepository,
 )
 from planner_service import PlannerService
 from recommendation_service import RecommendationService
@@ -56,6 +57,7 @@ class GymApp:
         self.game_repo = GamificationRepository()
         self.ml_models = MLModelRepository()
         self.ml_logs = MLLogRepository()
+        self.body_weights_repo = BodyWeightRepository()
         self.gamification = GamificationService(
             self.game_repo,
             self.exercises,
@@ -94,6 +96,9 @@ class GymApp:
             self.volume_model,
             self.readiness_model,
             self.progress_model,
+            None,
+            None,
+            self.body_weights_repo,
         )
         self._state_init()
 


### PR DESCRIPTION
## Summary
- add `body_weight_logs` table and repository
- expose body weight logging and stats endpoints
- extend statistics service with weight history and stats
- integrate body weight repository into API and Streamlit app
- test new endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e05460208327b9075acbbbcf5377