### PR TITLE
Automatically use latest body weight

### DIFF
--- a/db.py
+++ b/db.py
@@ -1755,3 +1755,12 @@ class BodyWeightRepository(BaseRepository):
         query += " ORDER BY date;"
         rows = self.fetch_all(query, tuple(params))
         return [(int(r[0]), r[1], float(r[2])) for r in rows]
+
+    def fetch_latest_weight(self) -> float | None:
+        """Return the most recent logged body weight if available."""
+        row = self.fetch_all(
+            "SELECT weight FROM body_weight_logs ORDER BY date DESC LIMIT 1;"
+        )
+        if row:
+            return float(row[0][0])
+        return None

--- a/rest_api.py
+++ b/rest_api.py
@@ -92,6 +92,7 @@ class GymAPI:
             self.gamification,
             self.ml_service,
             self.goal_model,
+            self.body_weights,
         )
         self.statistics = StatisticsService(
             self.sets,

--- a/stats_service.py
+++ b/stats_service.py
@@ -42,6 +42,16 @@ class StatisticsService:
         self.adaptation_model = adaptation_model
         self.body_weights = body_weight_repo
 
+    def _current_body_weight(self) -> float:
+        """Fetch the latest logged body weight or fallback to settings."""
+        if self.body_weights is not None:
+            latest = self.body_weights.fetch_latest_weight()
+            if latest is not None:
+                return latest
+        if self.settings is not None:
+            return self.settings.get_float("body_weight", 80.0)
+        return 80.0
+
     def _alias_names(self, exercise: Optional[str]) -> List[str]:
         if not exercise:
             return self.exercise_names.fetch_all()
@@ -207,11 +217,7 @@ class StatisticsService:
             perf_factor, rpe_scores, rec_factor, tut_ratio
         )
         ac_ratio = ExercisePrescription._ac_ratio(weights, reps)
-        body_weight = (
-            self.settings.get_float("body_weight", 80.0)
-            if self.settings
-            else 80.0
-        )
+        body_weight = self._current_body_weight()
         rec_quality = ExercisePrescription._comprehensive_recovery_quality(
             None, None, None, body_weight
         )
@@ -253,11 +259,7 @@ class StatisticsService:
             else 1.0
         )
         workouts_per_month = float(len(set(times)))
-        body_weight = (
-            self.settings.get_float("body_weight", 80.0)
-            if self.settings
-            else 80.0
-        )
+        body_weight = self._current_body_weight()
 
         base = ExerciseProgressEstimator.predict_progress(
             weights,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -88,6 +88,7 @@ class GymApp:
             self.settings_repo,
             self.gamification,
             self.ml_service,
+            body_weight_repo=self.body_weights_repo,
         )
         self.stats = StatisticsService(
             self.sets,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1603,3 +1603,21 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(stats["avg"], 81.0, places=2)
         self.assertEqual(stats["min"], 80.0)
         self.assertEqual(stats["max"], 82.0)
+
+    def test_current_body_weight_latest_log(self) -> None:
+        d1 = "2023-01-01"
+        d2 = "2023-01-02"
+        self.client.post("/body_weight", params={"weight": 80.0, "date": d1})
+        self.client.post("/body_weight", params={"weight": 85.0, "date": d2})
+
+        weight = self.api.statistics._current_body_weight()
+        self.assertAlmostEqual(weight, 85.0)
+
+    def test_recommender_body_weight_latest_log(self) -> None:
+        d1 = "2023-01-01"
+        d2 = "2023-01-03"
+        self.client.post("/body_weight", params={"weight": 70.0, "date": d1})
+        self.client.post("/body_weight", params={"weight": 72.5, "date": d2})
+
+        weight = self.api.recommender._current_body_weight()
+        self.assertAlmostEqual(weight, 72.5)


### PR DESCRIPTION
## Summary
- add `fetch_latest_weight` to `BodyWeightRepository`
- use new method in statistics and recommendation services
- wire body weight repository into recommendation service
- adjust Streamlit and REST API initialisation
- test that services return the newest logged body weight

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e75158c483279bc62997925c8f74