### PR TITLE
Add velocity history analytics endpoint

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -732,6 +732,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/velocity_history")
+        def stats_velocity_history(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.velocity_history(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/stats/overview")
         def stats_overview(
             start_date: str = None,


### PR DESCRIPTION
## Summary
- add velocity history calculation in `StatisticsService`
- expose new `/stats/velocity_history` endpoint
- test new endpoint

## Testing
- `pytest tests/test_api.py::APITestCase::test_velocity_history_endpoint -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f4be8ffc8327bfae825ba6999996