### PR TITLE
Add muscle usage analytics endpoint

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -104,6 +104,7 @@ class GymAPI:
             self.injury_model,
             self.adaptation_model,
             self.body_weights,
+            self.equipment,
         )
         self.app = FastAPI()
         self._setup_routes()
@@ -707,6 +708,13 @@ class GymAPI:
             end_date: str = None,
         ):
             return self.statistics.equipment_usage(start_date, end_date)
+
+        @self.app.get("/stats/muscle_usage")
+        def stats_muscle_usage(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.muscle_usage(start_date, end_date)
 
         @self.app.get("/stats/rpe_distribution")
         def stats_rpe_distribution(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -100,6 +100,7 @@ class GymApp:
             None,
             None,
             self.body_weights_repo,
+            self.equipment,
         )
         self._state_init()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -692,6 +692,14 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(eq_stats[0]["equipment"], "Olympic Barbell")
         self.assertEqual(eq_stats[0]["sets"], 2)
 
+        resp = self.client.get("/stats/muscle_usage")
+        self.assertEqual(resp.status_code, 200)
+        mus_stats = resp.json()
+        target = next((m for m in mus_stats if m["muscle"] == "Pectoralis Major"), None)
+        self.assertIsNotNone(target)
+        self.assertEqual(target["sets"], 2)
+        self.assertAlmostEqual(target["volume"], 1880.0)
+
         resp = self.client.get(
             "/stats/rpe_distribution",
             params={"exercise": "Bench Press"},


### PR DESCRIPTION
## Summary
- extend `StatisticsService` with muscle usage calculation
- initialize service with `EquipmentRepository`
- add `/stats/muscle_usage` endpoint in REST API
- wire up service in Streamlit app
- verify new analytics via updated tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687928dad5ec832792fdea1cc091e937