### PR TITLE
Add body weight forecast analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - All settings can be changed in the UI or by editing `settings.yaml` and remain synchronized.
 - Calculate average rest times between sets via `/stats/rest_times`.
 - Track body weight over time using `/body_weight` endpoints and `/stats/weight_stats`.
+- Forecast future body weight trends with `/stats/weight_forecast`.
 
 ## Installation
 

--- a/rest_api.py
+++ b/rest_api.py
@@ -1108,6 +1108,10 @@ class GymAPI:
         def stats_weight_stats(start_date: str = None, end_date: str = None):
             return self.statistics.weight_stats(start_date, end_date)
 
+        @self.app.get("/stats/weight_forecast")
+        def stats_weight_forecast(days: int):
+            return self.statistics.weight_forecast(days)
+
         @self.app.get("/stats/bmi")
         def stats_bmi():
             return {"bmi": self.statistics.bmi()}


### PR DESCRIPTION
## Summary
- implement `weight_forecast` method in `StatisticsService`
- expose `/stats/weight_forecast` endpoint via REST API
- document body weight forecast endpoint in README
- test new forecast functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792f038aa48327949c0f2ca904168e