### PR TITLE
Add wellness tracking feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,3 +417,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Add tests for all new analytics endpoints verifying expected numeric results.
 - The RPE machine learning model must utilise reps, weight and previous RPE when training or predicting.
 - Always record model predictions with their confidence values in the `ml_logs` table for later analysis.
+- Wellness logs must be stored in `wellness_logs` table with calories, sleep hours, sleep quality and stress level. Endpoints must support filtering by date range.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Multi-modal adaptation index fuses stress, fatigue and variability metrics using a deep learning model.
 - Utilities such as pyramid strength tests and warm‑up weight suggestions.
 - All settings can be changed in the UI or by editing `settings.yaml` and remain synchronized.
+- Log daily wellness metrics like calories, sleep and stress and view summary statistics.
 - Calculate average rest times between sets via `/stats/rest_times`.
 - Track body weight over time using `/body_weight` endpoints and `/stats/weight_stats`.
 - Forecast future body weight trends with `/stats/weight_forecast`.


### PR DESCRIPTION
## Summary
- add wellness logs table and repository
- expose wellness logging and summary endpoints
- log wellness information via Streamlit
- track wellness history and compute averages
- document new feature in README
- test wellness endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687930c6fc08832791001ff95c896398