### PR TITLE
Add intensity distribution analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,3 +418,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - The RPE machine learning model must utilise reps, weight and previous RPE when training or predicting.
 - Always record model predictions with their confidence values in the `ml_logs` table for later analysis.
 - Wellness logs must be stored in `wellness_logs` table with calories, sleep hours, sleep quality and stress level. Endpoints must support filtering by date range.
+- Intensity distribution analytics must bucket sets into 10% 1RM zones and be available via `/stats/intensity_distribution`.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - All settings can be changed in the UI or by editing `settings.yaml` and remain synchronized.
 - Log daily wellness metrics like calories, sleep and stress and view summary statistics.
 - Calculate average rest times between sets via `/stats/rest_times`.
+- Analyze training intensity zones with `/stats/intensity_distribution`.
 - Track body weight over time using `/body_weight` endpoints and `/stats/weight_stats`.
 - Forecast future body weight trends with `/stats/weight_forecast`.
 

--- a/rest_api.py
+++ b/rest_api.py
@@ -743,6 +743,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/intensity_distribution")
+        def stats_intensity_distribution(
+            exercise: str = None,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.intensity_distribution(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/stats/velocity_history")
         def stats_velocity_history(
             exercise: str,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -740,6 +740,17 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(rep_dist[1]["count"], 1)
 
         resp = self.client.get(
+            "/stats/intensity_distribution",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        intensity = resp.json()
+        zone = next((z for z in intensity if z["zone"] == "70-80"), None)
+        self.assertIsNotNone(zone)
+        self.assertEqual(zone["sets"], 2)
+        self.assertAlmostEqual(zone["volume"], 1880.0)
+
+        resp = self.client.get(
             "/prediction/progress",
             params={"exercise": "Bench Press", "weeks": 2, "workouts": 1},
         )


### PR DESCRIPTION
## Summary
- compute intensity distribution in `StatisticsService`
- expose `/stats/intensity_distribution` endpoint
- test intensity zone results via API
- document intensity feature
- document new rule for AGENTS

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687940c0c904832791ec75b67b5ad694