### PR TITLE
Add muscle group usage analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Log daily wellness metrics like calories, sleep and stress and view summary statistics.
 - Calculate average rest times between sets via `/stats/rest_times`.
 - Analyze training intensity zones with `/stats/intensity_distribution`.
+- Summarize volume by muscle group with `/stats/muscle_group_usage`.
 - Track body weight over time using `/body_weight` endpoints and `/stats/weight_stats`.
 - Forecast future body weight trends with `/stats/weight_forecast`.
 

--- a/rest_api.py
+++ b/rest_api.py
@@ -108,6 +108,7 @@ class GymAPI:
             self.body_weights,
             self.equipment,
             self.wellness,
+            self.exercise_catalog,
         )
         self.app = FastAPI()
         self._setup_routes()
@@ -718,6 +719,13 @@ class GymAPI:
             end_date: str = None,
         ):
             return self.statistics.muscle_usage(start_date, end_date)
+
+        @self.app.get("/stats/muscle_group_usage")
+        def stats_muscle_group_usage(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.muscle_group_usage(start_date, end_date)
 
         @self.app.get("/stats/rpe_distribution")
         def stats_rpe_distribution(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -210,6 +210,10 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.client.post("/workouts")
         self.client.post(
+            "/exercise_names/link",
+            params={"name1": "Barbell Bench Press", "name2": "Bench Press"},
+        )
+        self.client.post(
             "/workouts/1/exercises",
             params={"name": "Bench Press", "equipment": "Olympic Barbell"},
         )
@@ -649,6 +653,10 @@ class APITestCase(unittest.TestCase):
     def test_statistics_endpoints(self) -> None:
         self.client.post("/workouts")
         self.client.post(
+            "/exercise_names/link",
+            params={"name1": "Barbell Bench Press", "name2": "Bench Press"},
+        )
+        self.client.post(
             "/workouts/1/exercises",
             params={"name": "Bench Press", "equipment": "Olympic Barbell"},
         )
@@ -704,6 +712,14 @@ class APITestCase(unittest.TestCase):
         self.assertIsNotNone(target)
         self.assertEqual(target["sets"], 2)
         self.assertAlmostEqual(target["volume"], 1880.0)
+
+        resp = self.client.get("/stats/muscle_group_usage")
+        self.assertEqual(resp.status_code, 200)
+        grp_stats = resp.json()
+        chest = next((g for g in grp_stats if g["muscle_group"] == "Chest"), None)
+        self.assertIsNotNone(chest)
+        self.assertEqual(chest["sets"], 2)
+        self.assertAlmostEqual(chest["volume"], 1880.0)
 
         resp = self.client.get(
             "/stats/rpe_distribution",


### PR DESCRIPTION
## Summary
- extend `StatisticsService` to include exercise catalog for muscle group metrics
- implement `muscle_group_usage` analytics
- expose `/stats/muscle_group_usage` endpoint
- document new endpoint in README
- test muscle group usage in API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687942bd9e148327b1eea62f6b1d6b21