### PR TITLE
Add exercise frequency analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,3 +419,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Always record model predictions with their confidence values in the `ml_logs` table for later analysis.
 - Wellness logs must be stored in `wellness_logs` table with calories, sleep hours, sleep quality and stress level. Endpoints must support filtering by date range.
 - Intensity distribution analytics must bucket sets into 10% 1RM zones and be available via `/stats/intensity_distribution`.
+- Analytics endpoints should return results sorted by their key fields for consistent ordering.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Calculate average rest times between sets via `/stats/rest_times`.
 - Analyze training intensity zones with `/stats/intensity_distribution`.
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.
+- Evaluate exercise frequency per week with `/stats/exercise_frequency`.
 - Track body weight over time using `/body_weight` endpoints and `/stats/weight_stats`.
 - Forecast future body weight trends with `/stats/weight_forecast`.
 

--- a/rest_api.py
+++ b/rest_api.py
@@ -763,6 +763,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/exercise_frequency")
+        def stats_exercise_frequency(
+            exercise: str = None,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.exercise_frequency(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/stats/velocity_history")
         def stats_velocity_history(
             exercise: str,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1258,6 +1258,10 @@ class GymApp:
             data.sort(key=lambda x: x["volume"], reverse=True)
             if data:
                 st.table(data[:5])
+        with st.expander("Exercise Frequency", expanded=True):
+            freq = self.stats.exercise_frequency(None, start_str, end_str)
+            if freq:
+                st.table(freq)
         with st.expander("Equipment Usage", expanded=True):
             eq_stats = self.stats.equipment_usage(start_str, end_str)
             if eq_stats:
@@ -1793,7 +1797,11 @@ class GymApp:
                     "Sleep Hours", min_value=0.0, step=0.5, key="well_sleep"
                 )
                 sleep_q = st.number_input(
-                    "Sleep Quality", min_value=0.0, max_value=5.0, step=1.0, key="well_quality"
+                    "Sleep Quality",
+                    min_value=0.0,
+                    max_value=5.0,
+                    step=1.0,
+                    key="well_quality",
                 )
                 stress = st.number_input(
                     "Stress Level", min_value=0, max_value=10, step=1, key="well_stress"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1807,3 +1807,37 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(summary["avg_sleep"], 7.75)
         self.assertAlmostEqual(summary["avg_quality"], 3.5)
         self.assertAlmostEqual(summary["avg_stress"], 2.5)
+
+    def test_exercise_frequency(self) -> None:
+        d1 = (datetime.date.today() - datetime.timedelta(days=7)).isoformat()
+        d2 = datetime.date.today().isoformat()
+
+        self.client.post("/workouts", params={"date": d1})
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 8},
+        )
+
+        self.client.post("/workouts", params={"date": d2})
+        self.client.post(
+            "/workouts/2/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/exercises/2/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 8},
+        )
+
+        resp = self.client.get(
+            "/stats/exercise_frequency",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["exercise"], "Bench Press")
+        self.assertAlmostEqual(data[0]["frequency_per_week"], 1.0)


### PR DESCRIPTION
## Summary
- implement weekly exercise frequency analytics
- expose frequency via `/stats/exercise_frequency`
- display exercise frequency table in Reports tab
- document new endpoint and rule in AGENTS
- test exercise frequency API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687945d5bffc83279e63f03cea922911