### PR TITLE
Add workout notes feature

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -393,6 +393,7 @@ class GymApp:
                     start_time = detail[2]
                     end_time = detail[3]
                     current_type = detail[4]
+                    notes_val = detail[5] or ""
                     cols = st.columns(3)
                     if cols[0].button("Start Workout", key=f"start_workout_{selected}"):
                         self.workouts.set_start_time(
@@ -418,6 +419,13 @@ class GymApp:
                         st.write(f"Start: {start_time}")
                     if end_time:
                         st.write(f"End: {end_time}")
+                    notes_edit = st.text_area(
+                        "Notes",
+                        value=notes_val,
+                        key=f"workout_notes_{selected}",
+                    )
+                    if st.button("Save Notes", key=f"save_notes_{selected}"):
+                        self.workouts.set_note(int(selected), notes_edit)
                     csv_data = self.sets.export_workout_csv(int(selected))
                     st.download_button(
                         label="Export CSV",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -883,6 +883,28 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get(f"/workouts/{wid}")
         self.assertEqual(resp.json()["training_type"], "strength")
 
+    def test_workout_notes(self) -> None:
+        resp = self.client.post(
+            "/workouts",
+            params={"training_type": "strength", "notes": "felt good"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        wid = resp.json()["id"]
+
+        resp = self.client.get(f"/workouts/{wid}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["notes"], "felt good")
+
+        resp = self.client.put(
+            f"/workouts/{wid}/note",
+            params={"notes": "tired"},
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get(f"/workouts/{wid}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["notes"], "tired")
+
     def test_backdated_workout(self) -> None:
         past_date = (datetime.date.today() - datetime.timedelta(days=3)).isoformat()
         resp = self.client.post(


### PR DESCRIPTION
## Summary
- allow storing notes for workouts in `workouts` table
- expose notes via REST API and GUI
- support updating notes
- test workout notes endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794897a0a08327b7bd281ec4180705