### PR TITLE
Add exercise notes functionality

### DIFF
--- a/gamification_service.py
+++ b/gamification_service.py
@@ -31,7 +31,7 @@ class GamificationService:
     def record_set(self, exercise_id: int, reps: int, weight: float, rpe: int) -> None:
         if not self.is_enabled():
             return
-        wid, _name, _eq = self.exercises.fetch_detail(exercise_id)
+        wid, _name, _eq, _note = self.exercises.fetch_detail(exercise_id)
         pts = self._points(reps, weight, rpe)
         self.repo.add(wid, pts)
 

--- a/planner_service.py
+++ b/planner_service.py
@@ -37,7 +37,7 @@ class PlannerService:
         )
         exercises = self.planned_exercises.fetch_for_workout(plan_id)
         for ex_id, name, equipment in exercises:
-            new_ex_id = self.exercises.add(workout_id, name, equipment)
+            new_ex_id = self.exercises.add(workout_id, name, equipment, None)
             sets = self.planned_sets.fetch_for_exercise(ex_id)
             for set_id, reps, weight, rpe in sets:
                 self.sets.add(

--- a/recommendation_service.py
+++ b/recommendation_service.py
@@ -53,7 +53,7 @@ class RecommendationService:
         return len(history) > 0
 
     def recommend_next_set(self, exercise_id: int) -> dict:
-        workout_id, name, _ = self.exercises.fetch_detail(exercise_id)
+        workout_id, name, _, _ = self.exercises.fetch_detail(exercise_id)
         alias_names = self.exercise_names.aliases(name)
         history = self.sets.fetch_history_by_names(
             alias_names, with_duration=True, with_workout_id=True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,7 +50,14 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{"id": 1, "name": "Bench Press", "equipment": "Olympic Barbell"}],
+            [
+                {
+                    "id": 1,
+                    "name": "Bench Press",
+                    "equipment": "Olympic Barbell",
+                    "note": None,
+                }
+            ],
         )
 
         response = self.client.post(
@@ -276,7 +283,14 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
-            [{"id": 1, "name": "Squat", "equipment": "Olympic Barbell"}],
+            [
+                {
+                    "id": 1,
+                    "name": "Squat",
+                    "equipment": "Olympic Barbell",
+                    "note": None,
+                }
+            ],
         )
 
         response = self.client.get("/exercises/1/sets")
@@ -407,7 +421,14 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get("/workouts/1/exercises")
         self.assertEqual(
             resp.json(),
-            [{"id": 1, "name": "Clean", "equipment": "Olympic Barbell"}],
+            [
+                {
+                    "id": 1,
+                    "name": "Clean",
+                    "equipment": "Olympic Barbell",
+                    "note": None,
+                }
+            ],
         )
 
         # custom equipment lifecycle
@@ -1863,3 +1884,23 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["exercise"], "Bench Press")
         self.assertAlmostEqual(data[0]["frequency_per_week"], 1.0)
+
+    def test_exercise_notes(self) -> None:
+        self.client.post("/workouts")
+        resp = self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell", "note": "Focus"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        ex_id = resp.json()["id"]
+
+        resp = self.client.get("/workouts/1/exercises")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()[0]["note"], "Focus")
+
+        resp = self.client.put(f"/exercises/{ex_id}/note", params={"note": "Updated"})
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get(f"/exercises/{ex_id}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["note"], "Updated")


### PR DESCRIPTION
## Summary
- extend `exercises` table with `note` column
- support adding and updating exercise notes through REST API
- show notes in exercise listings and Streamlit UI
- handle notes in services and planner
- add regression test covering exercise notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68794a568c8c832799467ed492c8abe5