### PR TITLE
Add favorite exercises management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Plan future workouts, duplicate plans and convert them to logged sessions.
 - Manage equipment and muscle mappings. Custom equipment can be added and linked to muscles.
 - Maintain an exercise catalog with primary/secondary muscles and available equipment.
+- Mark favorite exercises for quick access in the library.
 - Create aliases for muscles and exercise names so queries treat them as the same entry.
 - Extensive statistics including daily volume, progression forecasts, stress metrics, readiness scores and personal records.
 - Optional gamification awarding points for completed sets.

--- a/db.py
+++ b/db.py
@@ -248,6 +248,12 @@ class Database:
                 "stress_level",
             ],
         ),
+        "favorite_exercises": (
+            """CREATE TABLE favorite_exercises (
+                    name TEXT PRIMARY KEY
+                );""",
+            ["name"],
+        ),
     }
 
     def __init__(self, db_path: str = "workout.db") -> None:
@@ -1934,3 +1940,25 @@ class WellnessRepository(BaseRepository):
         if not rows:
             raise ValueError("log not found")
         self.execute("DELETE FROM wellness_logs WHERE id = ?;", (entry_id,))
+
+
+class FavoriteExerciseRepository(BaseRepository):
+    """Repository for managing favorite exercises."""
+
+    def add(self, name: str) -> None:
+        self.execute(
+            "INSERT OR IGNORE INTO favorite_exercises (name) VALUES (?);",
+            (name,),
+        )
+
+    def remove(self, name: str) -> None:
+        self.execute(
+            "DELETE FROM favorite_exercises WHERE name = ?;",
+            (name,),
+        )
+
+    def fetch_all(self) -> list[str]:
+        rows = super().fetch_all(
+            "SELECT name FROM favorite_exercises ORDER BY name;"
+        )
+        return [r[0] for r in rows]

--- a/rest_api.py
+++ b/rest_api.py
@@ -19,6 +19,7 @@ from db import (
     MLLogRepository,
     BodyWeightRepository,
     WellnessRepository,
+    FavoriteExerciseRepository,
 )
 from planner_service import PlannerService
 from recommendation_service import RecommendationService
@@ -52,6 +53,7 @@ class GymAPI:
         self.exercise_catalog = ExerciseCatalogRepository(db_path)
         self.muscles = MuscleRepository(db_path)
         self.exercise_names = ExerciseNameRepository(db_path)
+        self.favorites = FavoriteExerciseRepository(db_path)
         self.settings = SettingsRepository(db_path, yaml_path)
         self.pyramid_tests = PyramidTestRepository(db_path)
         self.pyramid_entries = PyramidEntryRepository(db_path)
@@ -171,6 +173,20 @@ class GymAPI:
         def add_exercise_alias(new_name: str, existing: str):
             self.exercise_names.add_alias(new_name, existing)
             return {"status": "added"}
+
+        @self.app.get("/favorites/exercises")
+        def list_favorite_exercises():
+            return self.favorites.fetch_all()
+
+        @self.app.post("/favorites/exercises")
+        def add_favorite_exercise(name: str):
+            self.favorites.add(name)
+            return {"status": "added"}
+
+        @self.app.delete("/favorites/exercises/{name}")
+        def delete_favorite_exercise(name: str):
+            self.favorites.remove(name)
+            return {"status": "deleted"}
 
         @self.app.get("/exercise_catalog/muscle_groups")
         def list_muscle_groups():

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -20,6 +20,7 @@ from db import (
     MLLogRepository,
     BodyWeightRepository,
     WellnessRepository,
+    FavoriteExerciseRepository,
 )
 from planner_service import PlannerService
 from recommendation_service import RecommendationService
@@ -53,6 +54,7 @@ class GymApp:
         self.exercise_catalog = ExerciseCatalogRepository()
         self.muscles_repo = MuscleRepository()
         self.exercise_names_repo = ExerciseNameRepository()
+        self.favorites_repo = FavoriteExerciseRepository()
         self.pyramid_tests = PyramidTestRepository()
         self.pyramid_entries = PyramidEntryRepository()
         self.game_repo = GamificationRepository()
@@ -905,6 +907,25 @@ class GymApp:
     def _exercise_catalog_library(self) -> None:
         groups = self.exercise_catalog.fetch_muscle_groups()
         muscles = self.muscles_repo.fetch_all()
+        favs = self.favorites_repo.fetch_all()
+        with st.expander("Favorite Exercises", expanded=True):
+            if favs:
+                for f in favs:
+                    cols = st.columns(2)
+                    cols[0].write(f)
+                    if cols[1].button("Remove", key=f"fav_rm_{f}"):
+                        self.favorites_repo.remove(f)
+                        st.experimental_rerun()
+            else:
+                st.write("No favorites.")
+            add_choice = st.selectbox(
+                "Add Favorite",
+                [""] + self.exercise_names_repo.fetch_all(),
+                key="fav_add_name",
+            )
+            if st.button("Add Favorite", key="fav_add_btn") and add_choice:
+                self.favorites_repo.add(add_choice)
+                st.experimental_rerun()
         with st.expander("Filters", expanded=True):
             sel_groups = st.multiselect("Muscle Groups", groups, key="lib_ex_groups")
             sel_mus = st.multiselect("Muscles", muscles, key="lib_ex_mus")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1904,3 +1904,22 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get(f"/exercises/{ex_id}")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["note"], "Updated")
+
+    def test_favorite_exercises(self) -> None:
+        resp = self.client.post(
+            "/favorites/exercises",
+            params={"name": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "added"})
+
+        resp = self.client.get("/favorites/exercises")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("Bench Press", resp.json())
+
+        resp = self.client.delete("/favorites/exercises/Bench Press")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "deleted"})
+
+        resp = self.client.get("/favorites/exercises")
+        self.assertNotIn("Bench Press", resp.json())


### PR DESCRIPTION
## Summary
- introduce `favorite_exercises` table and repository
- expose REST endpoints to list/add/remove favorite exercises
- integrate favorites management in the Streamlit exercise library
- document feature in README
- test new REST endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794e1e45dc8327a5c3ff25db7ca2ec