### PR TITLE
Add workout location field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,3 +420,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Wellness logs must be stored in `wellness_logs` table with calories, sleep hours, sleep quality and stress level. Endpoints must support filtering by date range.
 - Intensity distribution analytics must bucket sets into 10% 1RM zones and be available via `/stats/intensity_distribution`.
 - Analytics endpoints should return results sorted by their key fields for consistent ordering.
+- Workouts may record an optional location which must be editable via REST endpoints and the Streamlit GUI.

--- a/db.py
+++ b/db.py
@@ -20,9 +20,18 @@ class Database:
                     start_time TEXT,
                     end_time TEXT,
                     training_type TEXT NOT NULL DEFAULT 'strength',
-                    notes TEXT
+                    notes TEXT,
+                    location TEXT
                 );""",
-            ["id", "date", "start_time", "end_time", "training_type", "notes"],
+            [
+                "id",
+                "date",
+                "start_time",
+                "end_time",
+                "training_type",
+                "notes",
+                "location",
+            ],
         ),
         "equipment": (
             """CREATE TABLE equipment (
@@ -483,10 +492,11 @@ class WorkoutRepository(BaseRepository):
         date: str,
         training_type: str = "strength",
         notes: str | None = None,
+        location: str | None = None,
     ) -> int:
         return self.execute(
-            "INSERT INTO workouts (date, training_type, notes) VALUES (?, ?, ?);",
-            (date, training_type, notes),
+            "INSERT INTO workouts (date, training_type, notes, location) VALUES (?, ?, ?, ?);",
+            (date, training_type, notes, location),
         )
 
     def fetch_all_workouts(
@@ -525,11 +535,17 @@ class WorkoutRepository(BaseRepository):
             (training_type, workout_id),
         )
 
+    def set_location(self, workout_id: int, location: Optional[str]) -> None:
+        self.execute(
+            "UPDATE workouts SET location = ? WHERE id = ?;",
+            (location, workout_id),
+        )
+
     def fetch_detail(
         self, workout_id: int
-    ) -> Tuple[int, str, Optional[str], Optional[str], str, Optional[str]]:
+    ) -> Tuple[int, str, Optional[str], Optional[str], str, Optional[str], Optional[str]]:
         rows = self.fetch_all(
-            "SELECT id, date, start_time, end_time, training_type, notes FROM workouts WHERE id = ?;",
+            "SELECT id, date, start_time, end_time, training_type, notes, location FROM workouts WHERE id = ?;",
             (workout_id,),
         )
         if not rows:

--- a/planner_service.py
+++ b/planner_service.py
@@ -33,7 +33,10 @@ class PlannerService:
     def create_workout_from_plan(self, plan_id: int) -> int:
         _pid, date, t_type = self.planned_workouts.fetch_detail(plan_id)
         workout_id = self.workouts.create(
-            date, t_type
+            date,
+            t_type,
+            None,
+            None,
         )
         exercises = self.planned_exercises.fetch_for_workout(plan_id)
         for ex_id, name, equipment in exercises:

--- a/rest_api.py
+++ b/rest_api.py
@@ -329,6 +329,7 @@ class GymAPI:
             date: str = None,
             training_type: str = "strength",
             notes: str | None = None,
+            location: str | None = None,
         ):
             try:
                 workout_date = (
@@ -346,6 +347,7 @@ class GymAPI:
                 workout_date.isoformat(),
                 training_type,
                 notes,
+                location,
             )
             return {"id": workout_id}
 
@@ -387,6 +389,7 @@ class GymAPI:
                 end_time,
                 training_type,
                 notes,
+                location,
             ) = self.workouts.fetch_detail(workout_id)
             return {
                 "id": wid,
@@ -395,6 +398,7 @@ class GymAPI:
                 "end_time": end_time,
                 "training_type": training_type,
                 "notes": notes,
+                "location": location,
             }
 
         @self.app.get("/workouts/{workout_id}/export_csv")
@@ -416,6 +420,11 @@ class GymAPI:
         @self.app.put("/workouts/{workout_id}/note")
         def update_workout_note(workout_id: int, notes: str = None):
             self.workouts.set_note(workout_id, notes)
+            return {"status": "updated"}
+
+        @self.app.put("/workouts/{workout_id}/location")
+        def update_workout_location(workout_id: int, location: str = None):
+            self.workouts.set_location(workout_id, location)
             return {"status": "updated"}
 
         @self.app.post("/workouts/{workout_id}/start")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -190,6 +190,8 @@ class GymApp:
             wid = self.workouts.create(
                 datetime.date.today().isoformat(),
                 "strength",
+                None,
+                None,
             )
             st.session_state.selected_workout = wid
             st.sidebar.success(f"Created workout {wid}")
@@ -376,9 +378,13 @@ class GymApp:
                 new_type = st.selectbox(
                     "Training Type", training_options, key="new_workout_type"
                 )
+                new_location = st.text_input("Location", key="new_workout_location")
                 if st.button("New Workout"):
                     new_id = self.workouts.create(
-                        datetime.date.today().isoformat(), new_type
+                        datetime.date.today().isoformat(),
+                        new_type,
+                        None,
+                        new_location or None,
                     )
                     st.session_state.selected_workout = new_id
             with st.expander("Existing Workouts", expanded=True):
@@ -396,6 +402,7 @@ class GymApp:
                     end_time = detail[3]
                     current_type = detail[4]
                     notes_val = detail[5] or ""
+                    loc_val = detail[6] or ""
                     cols = st.columns(3)
                     if cols[0].button("Start Workout", key=f"start_workout_{selected}"):
                         self.workouts.set_start_time(
@@ -428,6 +435,13 @@ class GymApp:
                     )
                     if st.button("Save Notes", key=f"save_notes_{selected}"):
                         self.workouts.set_note(int(selected), notes_edit)
+                    loc_edit = st.text_input(
+                        "Location",
+                        value=loc_val,
+                        key=f"workout_location_{selected}",
+                    )
+                    if st.button("Save Location", key=f"save_location_{selected}"):
+                        self.workouts.set_location(int(selected), loc_edit or None)
                     csv_data = self.sets.export_workout_csv(int(selected))
                     st.download_button(
                         label="Export CSV",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -927,6 +927,27 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["notes"], "tired")
 
+    def test_workout_location(self) -> None:
+        resp = self.client.post(
+            "/workouts",
+            params={"training_type": "strength", "location": "Home"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        wid = resp.json()["id"]
+
+        resp = self.client.get(f"/workouts/{wid}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["location"], "Home")
+
+        resp = self.client.put(
+            f"/workouts/{wid}/location",
+            params={"location": "Gym"},
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get(f"/workouts/{wid}")
+        self.assertEqual(resp.json()["location"], "Gym")
+
     def test_set_notes(self) -> None:
         self.client.post("/workouts")
         self.client.post(


### PR DESCRIPTION
## Summary
- support optional workout location in DB
- expose location via REST endpoints
- allow editing workout location in Streamlit UI
- test workout location API
- document location requirement in AGENTS rules

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879538a43408327b98ac90ffd064e2e