### PR TITLE
Add workout tag feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,3 +421,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Intensity distribution analytics must bucket sets into 10% 1RM zones and be available via `/stats/intensity_distribution`.
 - Analytics endpoints should return results sorted by their key fields for consistent ordering.
 - Workouts may record an optional location which must be editable via REST endpoints and the Streamlit GUI.
+- Workouts can be labeled with user-defined tags managed via the settings tab. Tags must be assignable through REST endpoints and the Streamlit GUI.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1965,6 +1965,32 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get("/favorites/exercises")
         self.assertNotIn("Bench Press", resp.json())
 
+    def test_workout_tags(self) -> None:
+        t_resp = self.client.post("/tags", params={"name": "Upper"})
+        self.assertEqual(t_resp.status_code, 200)
+        tid = t_resp.json()["id"]
+
+        self.client.post("/workouts")
+        add_resp = self.client.post("/workouts/1/tags", params={"tag_id": tid})
+        self.assertEqual(add_resp.status_code, 200)
+
+        list_resp = self.client.get("/workouts/1/tags")
+        self.assertEqual(list_resp.status_code, 200)
+        self.assertEqual(list_resp.json(), [{"id": tid, "name": "Upper"}])
+
+        upd = self.client.put(f"/tags/{tid}", params={"name": "UpperA"})
+        self.assertEqual(upd.status_code, 200)
+
+        tags = self.client.get("/tags").json()
+        self.assertEqual(tags[0]["name"], "UpperA")
+
+        del_resp = self.client.delete(f"/workouts/1/tags/{tid}")
+        self.assertEqual(del_resp.status_code, 200)
+        self.assertEqual(self.client.get("/workouts/1/tags").json(), [])
+
+        self.client.delete(f"/tags/{tid}")
+        self.assertEqual(self.client.get("/tags").json(), [])
+
     def test_template_workflow(self) -> None:
         resp = self.client.post(
             "/templates",


### PR DESCRIPTION
## Summary
- allow tagging workouts via new `tags` and `workout_tags` tables
- support tag management endpoints in REST API
- manage workout tags in Streamlit UI under settings and per-workout
- include tests for workout tag workflow
- document new rule in AGENTS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687959196d508327b23f9ce12f56ad9d