### PR TITLE
Add workout rating feature

### DIFF
--- a/planner_service.py
+++ b/planner_service.py
@@ -46,6 +46,7 @@ class PlannerService:
             t_type,
             None,
             None,
+            None,
         )
         exercises = self.planned_exercises.fetch_for_workout(plan_id)
         for ex_id, name, equipment in exercises:

--- a/recommendation_service.py
+++ b/recommendation_service.py
@@ -93,7 +93,7 @@ class RecommendationService:
 
         sessions: list[dict] = []
         for wid in session_map:
-            wid_d, date, start, end, t_type = self.workouts.fetch_detail(wid)
+            wid_d, date, start, end, t_type, *_ = self.workouts.fetch_detail(wid)
             sessions.append(
                 {
                     "id": wid_d,

--- a/rest_api.py
+++ b/rest_api.py
@@ -382,6 +382,7 @@ class GymAPI:
             training_type: str = "strength",
             notes: str | None = None,
             location: str | None = None,
+            rating: int | None = None,
         ):
             try:
                 workout_date = (
@@ -400,6 +401,7 @@ class GymAPI:
                 training_type,
                 notes,
                 location,
+                rating,
             )
             return {"id": workout_id}
 
@@ -416,7 +418,7 @@ class GymAPI:
         ):
             workouts = self.workouts.fetch_all_workouts(start_date, end_date)
             result = []
-            for wid, date, _s, _e, t_type, _notes in workouts:
+            for wid, date, _s, _e, t_type, _notes, _rating in workouts:
                 if training_type and t_type != training_type:
                     continue
                 summary = self.sets.workout_summary(wid)
@@ -442,6 +444,7 @@ class GymAPI:
                 training_type,
                 notes,
                 location,
+                rating,
             ) = self.workouts.fetch_detail(workout_id)
             return {
                 "id": wid,
@@ -451,6 +454,7 @@ class GymAPI:
                 "training_type": training_type,
                 "notes": notes,
                 "location": location,
+                "rating": rating,
             }
 
         @self.app.get("/workouts/{workout_id}/export_csv")
@@ -477,6 +481,11 @@ class GymAPI:
         @self.app.put("/workouts/{workout_id}/location")
         def update_workout_location(workout_id: int, location: str = None):
             self.workouts.set_location(workout_id, location)
+            return {"status": "updated"}
+
+        @self.app.put("/workouts/{workout_id}/rating")
+        def update_workout_rating(workout_id: int, rating: int | None = None):
+            self.workouts.set_rating(workout_id, rating)
             return {"status": "updated"}
 
         @self.app.post("/workouts/{workout_id}/start")
@@ -519,7 +528,9 @@ class GymAPI:
             return {"status": "finished", "timestamp": timestamp}
 
         @self.app.post("/workouts/{workout_id}/exercises")
-        def add_exercise(workout_id: int, name: str, equipment: str, note: str | None = None):
+        def add_exercise(
+            workout_id: int, name: str, equipment: str, note: str | None = None
+        ):
             if not equipment:
                 raise HTTPException(status_code=400, detail="equipment required")
             ex_id = self.exercises.add(workout_id, name, equipment, note)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -948,6 +948,27 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get(f"/workouts/{wid}")
         self.assertEqual(resp.json()["location"], "Gym")
 
+    def test_workout_rating(self) -> None:
+        resp = self.client.post(
+            "/workouts",
+            params={"training_type": "strength", "rating": 4},
+        )
+        self.assertEqual(resp.status_code, 200)
+        wid = resp.json()["id"]
+
+        resp = self.client.get(f"/workouts/{wid}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["rating"], 4)
+
+        resp = self.client.put(
+            f"/workouts/{wid}/rating",
+            params={"rating": 5},
+        )
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get(f"/workouts/{wid}")
+        self.assertEqual(resp.json()["rating"], 5)
+
     def test_set_notes(self) -> None:
         self.client.post("/workouts")
         self.client.post(
@@ -1930,7 +1951,11 @@ class APITestCase(unittest.TestCase):
         self.client.post("/workouts")
         resp = self.client.post(
             "/workouts/1/exercises",
-            params={"name": "Bench Press", "equipment": "Olympic Barbell", "note": "Focus"},
+            params={
+                "name": "Bench Press",
+                "equipment": "Olympic Barbell",
+                "note": "Focus",
+            },
         )
         self.assertEqual(resp.status_code, 200)
         ex_id = resp.json()["id"]


### PR DESCRIPTION
## Summary
- add `rating` column to workouts table
- support rating when creating and updating workouts via REST API
- expose rating in workout details and allow editing in Streamlit
- adjust recommendation service and planner for new schema
- test workout rating functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795cd339c48327aa9181cddbf1f4bf