### PR TITLE
Add favorite template management

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Manage equipment and muscle mappings. Custom equipment can be added and linked to muscles.
 - Maintain an exercise catalog with primary/secondary muscles and available equipment.
 - Mark favorite exercises for quick access in the library.
+- Mark favorite workout templates for faster planning.
 - Create aliases for muscles and exercise names so queries treat them as the same entry.
 - Extensive statistics including daily volume, progression forecasts, stress metrics, readiness scores and personal records.
 - Optional gamification awarding points for completed sets.

--- a/db.py
+++ b/db.py
@@ -297,6 +297,13 @@ class Database:
                 );""",
             ["name"],
         ),
+        "favorite_templates": (
+            """CREATE TABLE favorite_templates (
+                    template_id INTEGER PRIMARY KEY,
+                    FOREIGN KEY(template_id) REFERENCES workout_templates(id) ON DELETE CASCADE
+                );""",
+            ["template_id"],
+        ),
         "tags": (
             """CREATE TABLE tags (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2050,6 +2057,28 @@ class FavoriteExerciseRepository(BaseRepository):
     def fetch_all(self) -> list[str]:
         rows = super().fetch_all("SELECT name FROM favorite_exercises ORDER BY name;")
         return [r[0] for r in rows]
+
+
+class FavoriteTemplateRepository(BaseRepository):
+    """Repository for managing favorite workout templates."""
+
+    def add(self, template_id: int) -> None:
+        self.execute(
+            "INSERT OR IGNORE INTO favorite_templates (template_id) VALUES (?);",
+            (template_id,),
+        )
+
+    def remove(self, template_id: int) -> None:
+        self.execute(
+            "DELETE FROM favorite_templates WHERE template_id = ?;",
+            (template_id,),
+        )
+
+    def fetch_all(self) -> list[int]:
+        rows = super().fetch_all(
+            "SELECT template_id FROM favorite_templates ORDER BY template_id;"
+        )
+        return [int(r[0]) for r in rows]
 
 
 class TemplateWorkoutRepository(BaseRepository):

--- a/rest_api.py
+++ b/rest_api.py
@@ -23,6 +23,7 @@ from db import (
     BodyWeightRepository,
     WellnessRepository,
     FavoriteExerciseRepository,
+    FavoriteTemplateRepository,
     TagRepository,
 )
 from planner_service import PlannerService
@@ -61,6 +62,7 @@ class GymAPI:
         self.muscles = MuscleRepository(db_path)
         self.exercise_names = ExerciseNameRepository(db_path)
         self.favorites = FavoriteExerciseRepository(db_path)
+        self.favorite_templates = FavoriteTemplateRepository(db_path)
         self.tags = TagRepository(db_path)
         self.settings = SettingsRepository(db_path, yaml_path)
         self.pyramid_tests = PyramidTestRepository(db_path)
@@ -197,6 +199,20 @@ class GymAPI:
         @self.app.delete("/favorites/exercises/{name}")
         def delete_favorite_exercise(name: str):
             self.favorites.remove(name)
+            return {"status": "deleted"}
+
+        @self.app.get("/favorites/templates")
+        def list_favorite_templates():
+            return self.favorite_templates.fetch_all()
+
+        @self.app.post("/favorites/templates")
+        def add_favorite_template(template_id: int):
+            self.favorite_templates.add(template_id)
+            return {"status": "added"}
+
+        @self.app.delete("/favorites/templates/{template_id}")
+        def delete_favorite_template(template_id: int):
+            self.favorite_templates.remove(template_id)
             return {"status": "deleted"}
 
         @self.app.get("/tags")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -24,6 +24,7 @@ from db import (
     BodyWeightRepository,
     WellnessRepository,
     FavoriteExerciseRepository,
+    FavoriteTemplateRepository,
     TagRepository,
 )
 from planner_service import PlannerService
@@ -62,6 +63,7 @@ class GymApp:
         self.muscles_repo = MuscleRepository()
         self.exercise_names_repo = ExerciseNameRepository()
         self.favorites_repo = FavoriteExerciseRepository()
+        self.favorite_templates_repo = FavoriteTemplateRepository()
         self.tags_repo = TagRepository()
         self.pyramid_tests = PyramidTestRepository()
         self.pyramid_entries = PyramidEntryRepository()
@@ -940,6 +942,31 @@ class GymApp:
         st.header("Templates")
         training_options = ["strength", "hypertrophy", "highintensity"]
         with st.expander("Template Management", expanded=True):
+            favs = self.favorite_templates_repo.fetch_all()
+            with st.expander("Favorite Templates", expanded=True):
+                if favs:
+                    for fid in favs:
+                        try:
+                            _id, name, _type = self.template_workouts.fetch_detail(fid)
+                        except ValueError:
+                            continue
+                        cols = st.columns(2)
+                        cols[0].write(name)
+                        if cols[1].button("Remove", key=f"fav_tpl_rm_{fid}"):
+                            self.favorite_templates_repo.remove(fid)
+                            st.experimental_rerun()
+                else:
+                    st.write("No favorites.")
+                templates = {str(t[0]): t[1] for t in self.template_workouts.fetch_all()}
+                add_choice = st.selectbox(
+                    "Add Favorite",
+                    [""] + list(templates.keys()),
+                    format_func=lambda x: "" if x == "" else templates[x],
+                    key="fav_tpl_add_choice",
+                )
+                if st.button("Add Favorite", key="fav_tpl_add_btn") and add_choice:
+                    self.favorite_templates_repo.add(int(add_choice))
+                    st.experimental_rerun()
             with st.expander("Create New Template"):
                 name = st.text_input("Name", key="tmpl_name")
                 t_type = st.selectbox(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2050,3 +2050,29 @@ class APITestCase(unittest.TestCase):
         data = resp.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["name"], "Squat")
+
+    def test_favorite_templates(self) -> None:
+        resp = self.client.post(
+            "/templates",
+            params={"name": "Base", "training_type": "strength"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        tid = resp.json()["id"]
+
+        add_resp = self.client.post(
+            "/favorites/templates",
+            params={"template_id": tid},
+        )
+        self.assertEqual(add_resp.status_code, 200)
+        self.assertEqual(add_resp.json(), {"status": "added"})
+
+        list_resp = self.client.get("/favorites/templates")
+        self.assertEqual(list_resp.status_code, 200)
+        self.assertIn(tid, list_resp.json())
+
+        del_resp = self.client.delete(f"/favorites/templates/{tid}")
+        self.assertEqual(del_resp.status_code, 200)
+        self.assertEqual(del_resp.json(), {"status": "deleted"})
+
+        list_resp = self.client.get("/favorites/templates")
+        self.assertNotIn(tid, list_resp.json())


### PR DESCRIPTION
## Summary
- allow marking workout templates as favorites
- expose endpoints to manage favorite templates
- support favorite templates in the Streamlit UI
- add tests for favorite template workflow
- document new capability in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687960c3186883278551573055b2a130