### PR TITLE
Improve mobile layout handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,3 +422,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Analytics endpoints should return results sorted by their key fields for consistent ordering.
 - Workouts may record an optional location which must be editable via REST endpoints and the Streamlit GUI.
 - Workouts can be labeled with user-defined tags managed via the settings tab. Tags must be assignable through REST endpoints and the Streamlit GUI.
+- All responsive layout and mobile-specific styling must be defined within the `_inject_responsive_css` method in `streamlit_app.py` and must preserve all desktop functionality.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 
 ## Features
 
- - Fully responsive Streamlit interface with automatic layout detection for desktop and mobile devices.
+- Fully responsive Streamlit interface with automatic layout detection for desktop and mobile devices.
+- Mobile layouts stack columns vertically, resize charts and provide horizontal scrolling for wide tables.
 - REST API exposing every action used by the GUI.
 - Log workouts with training type, exercises and detailed sets. Each set stores reps, weight, RPE and timestamps.
 - Plan future workouts, duplicate plans and convert them to logged sessions.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -200,6 +200,17 @@ class GymApp:
                     white-space: nowrap;
                     width: 100%;
                 }
+                div[data-testid="metric-container"] > div {
+                    flex-direction: column;
+                    align-items: center;
+                }
+                body {
+                    overflow-x: hidden;
+                }
+                canvas {
+                    max-width: 100% !important;
+                    height: auto !important;
+                }
             }
             </style>
             """,


### PR DESCRIPTION
## Summary
- tweak responsive CSS for mobile layout
- document mobile layout improvements
- clarify AGENTS guidance for mobile styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e9e8eddc832791ed23510663506d