### PR TITLE
Improve mobile tab scrolling

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -211,6 +211,13 @@ class GymApp:
                     max-width: 100% !important;
                     height: auto !important;
                 }
+                div[data-testid="stTabs"] > div:first-child {
+                    overflow-x: auto;
+                    white-space: nowrap;
+                }
+                div[data-testid="stTabs"] button {
+                    flex-shrink: 0;
+                }
             }
             </style>
             """,


### PR DESCRIPTION
## Summary
- add mobile styles for horizontal tab scrolling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879f64d1b70832794a692442c340d48