### PR TITLE
Improve mobile layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,3 +423,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Workouts may record an optional location which must be editable via REST endpoints and the Streamlit GUI.
 - Workouts can be labeled with user-defined tags managed via the settings tab. Tags must be assignable through REST endpoints and the Streamlit GUI.
 - All responsive layout and mobile-specific styling must be defined within the `_inject_responsive_css` method in `streamlit_app.py` and must preserve all desktop functionality.
+- Mobile CSS must support landscape orientation adjustments without removing any functionality.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 
 ## Features
 
-- Fully responsive Streamlit interface with automatic layout detection for desktop and mobile devices.
+- Fully responsive Streamlit interface with automatic layout detection for desktop and mobile devices, including orientation-aware layouts.
 - Mobile layouts stack columns vertically, resize charts and provide horizontal scrolling for wide tables.
 - REST API exposing every action used by the GUI.
 - Log workouts with training type, exercises and detailed sets. Each set stores reps, weight, RPE and timestamps.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -187,12 +187,13 @@ class GymApp:
                 button[kind="secondary"] {
                     width: 100%;
                 }
-                div[data-testid="metric-container"] > label {
-                    font-size: 0.9rem;
-                }
+                textarea,
                 div[data-baseweb="input"] input,
                 div[data-baseweb="select"] {
                     width: 100% !important;
+                }
+                div[data-testid="metric-container"] > label {
+                    font-size: 0.9rem;
                 }
                 div[data-testid="stTable"] table {
                     display: block;
@@ -229,6 +230,16 @@ class GymApp:
                 }
                 h3 {
                     font-size: 1.25rem;
+                }
+            }
+
+            @media screen and (max-width: 768px) and (orientation: landscape) {
+                section.main > div {
+                    padding: 0.5rem !important;
+                }
+                div[data-testid="column"] {
+                    flex-direction: row;
+                    flex-wrap: wrap;
                 }
             }
             </style>

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -12,6 +12,8 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn("font-size: 1.75rem;", content)
         self.assertIn("font-size: 1.5rem;", content)
         self.assertIn("font-size: 1.25rem;", content)
+        self.assertIn("orientation: landscape", content)
+        self.assertIn("textarea,", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enhance responsive CSS for mobile screens and add orientation rules
- check mobile CSS in tests and document orientation support in README
- update AGENTS guidelines about landscape orientation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879fd4fd9088327b8d0180c45af469e