### PR TITLE
Improve mobile mode detection

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -138,7 +138,7 @@ class GymApp:
             st.components.v1.html(
                 """
                 <script>
-                const mode = window.innerWidth < 768 ? 'mobile' : 'desktop';
+                const mode = Math.min(window.innerWidth, window.innerHeight) < 768 ? 'mobile' : 'desktop';
                 const params = new URLSearchParams(window.location.search);
                 params.set('mode', mode);
                 window.location.search = params.toString();
@@ -159,7 +159,7 @@ class GymApp:
             """
             <script>
             function setMode() {
-                const mode = window.innerWidth < 768 ? 'mobile' : 'desktop';
+                const mode = Math.min(window.innerWidth, window.innerHeight) < 768 ? 'mobile' : 'desktop';
                 const params = new URLSearchParams(window.location.search);
                 const cur = params.get('mode');
                 if (mode !== cur) {

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -14,6 +14,7 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn("font-size: 1.25rem;", content)
         self.assertIn("orientation: landscape", content)
         self.assertIn("textarea,", content)
+        self.assertIn("Math.min", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- use smaller of width/height to decide mobile mode
- check for this script in tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a11a834448327922125483f75ee76