### PR TITLE
Add workout rating analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Track body weight over time using `/body_weight` endpoints and `/stats/weight_stats`.
 - Forecast future body weight trends with `/stats/weight_forecast`.
 - View weight history, BMI charts and forecasts in the Progress tab's new "Body Weight" section.
+- Review workout ratings via `/stats/rating_history` and `/stats/rating_stats`.
 
 ## Installation
 

--- a/db.py
+++ b/db.py
@@ -611,6 +611,24 @@ class WorkoutRepository(BaseRepository):
             (rating, workout_id),
         )
 
+    def fetch_ratings(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Tuple[str, int]]:
+        """Return all workout ratings within optional date range."""
+        query = "SELECT date, rating FROM workouts WHERE rating IS NOT NULL"
+        params: list[str] = []
+        if start_date:
+            query += " AND date >= ?"
+            params.append(start_date)
+        if end_date:
+            query += " AND date <= ?"
+            params.append(end_date)
+        query += " ORDER BY date;"
+        rows = self.fetch_all(query, tuple(params))
+        return [(d, int(r)) for d, r in rows]
+
     def fetch_detail(self, workout_id: int) -> Tuple[
         int,
         str,

--- a/rest_api.py
+++ b/rest_api.py
@@ -126,6 +126,7 @@ class GymAPI:
             self.equipment,
             self.wellness,
             self.exercise_catalog,
+            self.workouts,
         )
         self.app = FastAPI()
         self._setup_routes()
@@ -1474,6 +1475,14 @@ class GymAPI:
         @self.app.get("/stats/bmi_history")
         def stats_bmi_history(start_date: str = None, end_date: str = None):
             return self.statistics.bmi_history(start_date, end_date)
+
+        @self.app.get("/stats/rating_history")
+        def stats_rating_history(start_date: str = None, end_date: str = None):
+            return self.statistics.rating_history(start_date, end_date)
+
+        @self.app.get("/stats/rating_stats")
+        def stats_rating_stats(start_date: str = None, end_date: str = None):
+            return self.statistics.rating_stats(start_date, end_date)
 
         @self.app.get("/ml_logs/{model_name}")
         def get_ml_logs(model_name: str, start_date: str = None, end_date: str = None):

--- a/stats_service.py
+++ b/stats_service.py
@@ -36,6 +36,7 @@ class StatisticsService:
         equipment_repo: "EquipmentRepository" | None = None,
         wellness_repo: "WellnessRepository" | None = None,
         catalog_repo: "ExerciseCatalogRepository" | None = None,
+        workout_repo: "WorkoutRepository" | None = None,
     ) -> None:
         self.sets = set_repo
         self.exercise_names = name_repo
@@ -49,6 +50,7 @@ class StatisticsService:
         self.equipment = equipment_repo
         self.wellness = wellness_repo
         self.catalog = catalog_repo
+        self.workouts = workout_repo
 
     def _current_body_weight(self) -> float:
         """Fetch the latest logged body weight or fallback to settings."""
@@ -1213,6 +1215,28 @@ class StatisticsService:
             "avg": round(sum(weights) / len(weights), 2),
             "min": min(weights),
             "max": max(weights),
+        }
+
+    def rating_history(
+        self, start_date: Optional[str] = None, end_date: Optional[str] = None
+    ) -> List[Dict[str, int]]:
+        """Return workout ratings sorted by date."""
+        if self.workouts is None:
+            return []
+        rows = self.workouts.fetch_ratings(start_date, end_date)
+        return [{"date": d, "rating": r} for d, r in rows]
+
+    def rating_stats(
+        self, start_date: Optional[str] = None, end_date: Optional[str] = None
+    ) -> Dict[str, float]:
+        history = self.rating_history(start_date, end_date)
+        if not history:
+            return {"avg": 0.0, "min": 0.0, "max": 0.0}
+        ratings = [h["rating"] for h in history]
+        return {
+            "avg": round(sum(ratings) / len(ratings), 2),
+            "min": min(ratings),
+            "max": max(ratings),
         }
 
     def bmi(self) -> float:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2096,3 +2096,38 @@ class APITestCase(unittest.TestCase):
 
         list_resp = self.client.get("/favorites/workouts")
         self.assertNotIn(1, list_resp.json())
+
+    def test_rating_history_and_stats(self) -> None:
+        d1 = "2023-01-01"
+        d2 = "2023-01-02"
+        self.client.post(
+            "/workouts",
+            params={"date": d1, "training_type": "strength", "rating": 4},
+        )
+        self.client.post(
+            "/workouts",
+            params={"date": d2, "training_type": "strength", "rating": 5},
+        )
+
+        hist_resp = self.client.get(
+            "/stats/rating_history",
+            params={"start_date": d1, "end_date": d2},
+        )
+        self.assertEqual(hist_resp.status_code, 200)
+        self.assertEqual(
+            hist_resp.json(),
+            [
+                {"date": d1, "rating": 4},
+                {"date": d2, "rating": 5},
+            ],
+        )
+
+        stats_resp = self.client.get(
+            "/stats/rating_stats",
+            params={"start_date": d1, "end_date": d2},
+        )
+        self.assertEqual(stats_resp.status_code, 200)
+        stats = stats_resp.json()
+        self.assertAlmostEqual(stats["avg"], 4.5)
+        self.assertEqual(stats["min"], 4)
+        self.assertEqual(stats["max"], 5)


### PR DESCRIPTION
## Summary
- track workout ratings with new `fetch_ratings` in `WorkoutRepository`
- add `rating_history` and `rating_stats` methods in `StatisticsService`
- expose `/stats/rating_history` and `/stats/rating_stats` endpoints
- document rating endpoints in README
- test new analytics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0248c36c832783fdc3ca5e5e8302