### PR TITLE
Improve weighted fusion algorithm

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -109,6 +109,11 @@ class MathToolsTestCase(unittest.TestCase):
         expected = MathTools.clamp(10.0 - math.sqrt(2.0**2 + 3.0**2), 0.0, 10.0)
         self.assertAlmostEqual(val, expected)
 
+    def test_weighted_fusion_with_reliability(self) -> None:
+        result = MathTools.weighted_fusion(5.0, 0.3, 8.0, algo_conf=0.7, algo_reliability=0.5)
+        expected = (0.3 / (0.3 + 0.7 * 0.5)) * 5.0 + ((0.7 * 0.5) / (0.3 + 0.7 * 0.5)) * 8.0
+        self.assertAlmostEqual(result, expected)
+
     def test_periodization_and_velocity_loss(self) -> None:
         factor = ExercisePrescription._adaptive_periodization_factor([1.0, 1.1, 1.2, 1.3], 2)
         self.assertAlmostEqual(factor, 0.9)

--- a/tools.py
+++ b/tools.py
@@ -128,13 +128,15 @@ class MathTools:
         model_conf: float,
         algo_pred: float,
         algo_conf: float = 1.0,
+        algo_reliability: float = 1.0,
     ) -> float:
         """Fuse model and algorithm predictions using confidence weights."""
-        total = model_conf + algo_conf
+        adj_algo_conf = algo_conf * max(algo_reliability, 0.0)
+        total = model_conf + adj_algo_conf
         if total == 0:
             raise ValueError("total confidence cannot be zero")
         w_model = model_conf / total
-        w_algo = algo_conf / total
+        w_algo = adj_algo_conf / total
         return w_model * model_pred + w_algo * algo_pred
 
 


### PR DESCRIPTION
## Summary
- adjust weighted fusion to support algorithm reliability weighting
- test the enhanced weighted fusion functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0e4e4cc0832797e19bc7769fc676