### PR TITLE
Improve intensity distribution bins

### DIFF
--- a/stats_service.py
+++ b/stats_service.py
@@ -474,14 +474,8 @@ class StatisticsService:
             start_date=start_date,
             end_date=end_date,
         )
-        bins = [
-            (0.0, 0.5),
-            (0.5, 0.6),
-            (0.6, 0.7),
-            (0.7, 0.8),
-            (0.8, 0.9),
-            (0.9, 2.0),
-        ]
+        bins = [(i / 10.0, (i + 1) / 10.0) for i in range(10)]
+        bins.append((1.0, 2.0))
         stats = {
             f"{int(lo*100)}-{int(hi*100 if hi < 1.0 else 100)}": {
                 "sets": 0,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -783,6 +783,7 @@ class APITestCase(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         intensity = resp.json()
+        self.assertEqual(len(intensity), 11)
         zone = next((z for z in intensity if z["zone"] == "70-80"), None)
         self.assertIsNotNone(zone)
         self.assertEqual(zone["sets"], 2)


### PR DESCRIPTION
## Summary
- refine intensity distribution to use 10% 1RM bins
- verify updated zone count in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d178a11a48327b99fbf472f968fe1