### PR TITLE
Add daily muscle group volume analytics

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -969,6 +969,16 @@ class GymAPI:
         ):
             return self.statistics.muscle_group_usage(start_date, end_date)
 
+        @self.app.get("/stats/daily_muscle_group_volume")
+        def stats_daily_muscle_group_volume(
+            muscle_group: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.daily_muscle_group_volume(
+                muscle_group, start_date, end_date
+            )
+
         @self.app.get("/stats/rpe_distribution")
         def stats_rpe_distribution(
             exercise: str = None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -674,6 +674,7 @@ class APITestCase(unittest.TestCase):
 
     def test_statistics_endpoints(self) -> None:
         self.client.post("/workouts")
+        today = datetime.date.today().isoformat()
         self.client.post(
             "/exercise_names/link",
             params={"name1": "Barbell Bench Press", "name2": "Bench Press"},
@@ -742,6 +743,17 @@ class APITestCase(unittest.TestCase):
         self.assertIsNotNone(chest)
         self.assertEqual(chest["sets"], 2)
         self.assertAlmostEqual(chest["volume"], 1880.0)
+
+        resp = self.client.get(
+            "/stats/daily_muscle_group_volume",
+            params={"muscle_group": "Chest"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        mg_daily = resp.json()
+        self.assertEqual(len(mg_daily), 1)
+        self.assertEqual(mg_daily[0]["date"], today)
+        self.assertAlmostEqual(mg_daily[0]["volume"], 1880.0)
+        self.assertEqual(mg_daily[0]["sets"], 2)
 
         resp = self.client.get(
             "/stats/rpe_distribution",


### PR DESCRIPTION
## Summary
- compute daily muscle group volume in `StatisticsService`
- expose new `/stats/daily_muscle_group_volume` endpoint
- test daily muscle group volume

## Testing
- `pytest tests/test_api.py::APITestCase::test_statistics_endpoints -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1940ae608327a97cc502dc1a222f