### PR TITLE
Add location summary analytics endpoint

### DIFF
--- a/db.py
+++ b/db.py
@@ -889,6 +889,7 @@ class SetRepository(BaseRepository):
         with_equipment: bool = False,
         with_duration: bool = False,
         with_workout_id: bool = False,
+        with_location: bool = False,
     ) -> List[Tuple]:
         placeholders = ", ".join(["?" for _ in names])
         select = "SELECT s.reps, s.weight, s.rpe, w.date"
@@ -898,6 +899,8 @@ class SetRepository(BaseRepository):
             select += ", s.start_time, s.end_time"
         if with_workout_id:
             select += ", w.id"
+        if with_location:
+            select += ", w.location"
         query = (
             f"{select} FROM sets s "
             "JOIN exercises e ON s.exercise_id = e.id "

--- a/rest_api.py
+++ b/rest_api.py
@@ -1117,6 +1117,13 @@ class GymAPI:
         ):
             return self.statistics.rest_times(start_date, end_date)
 
+        @self.app.get("/stats/location_summary")
+        def stats_location_summary(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.location_summary(start_date, end_date)
+
         @self.app.get("/stats/volume_forecast")
         def stats_volume_forecast(
             days: int = 7,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1386,6 +1386,42 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(data[0]["workout_id"], 1)
         self.assertAlmostEqual(data[0]["avg_rest"], 60.0, places=2)
 
+    def test_location_summary_endpoint(self) -> None:
+        self.client.post(
+            "/workouts",
+            params={"date": "2023-01-01", "location": "Home"},
+        )
+        self.client.post(
+            "/workouts",
+            params={"date": "2023-01-02", "location": "Gym"},
+        )
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/workouts/2/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 8},
+        )
+        self.client.post(
+            "/exercises/2/sets",
+            params={"reps": 5, "weight": 110.0, "rpe": 8},
+        )
+        resp = self.client.get("/stats/location_summary")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["location"], "Gym")
+        self.assertEqual(data[0]["workouts"], 1)
+        self.assertAlmostEqual(data[0]["volume"], 550.0)
+        self.assertEqual(data[1]["location"], "Home")
+        self.assertEqual(data[1]["workouts"], 1)
+        self.assertAlmostEqual(data[1]["volume"], 500.0)
+
     def test_set_velocity_and_history(self) -> None:
         self.client.post("/workouts")
         self.client.post(


### PR DESCRIPTION
## Summary
- extend `fetch_history_by_names` to optionally include workout locations
- add `location_summary` method in `StatisticsService`
- expose `/stats/location_summary` endpoint in REST API
- test new analytics endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2c9ad0908327bb78b38df5ac2b63