### PR TITLE
Improve fatigue calculation

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -97,8 +97,14 @@ class MathToolsTestCase(unittest.TestCase):
         self.assertGreater(anomaly, 0.5)
 
     def test_enhanced_algorithms(self) -> None:
-        fatigue = ExercisePrescription._enhanced_fatigue([100, 110], [5, 5], [0, 1], 5)
-        self.assertAlmostEqual(fatigue, 992.5, places=1)
+        fatigue = ExercisePrescription._enhanced_fatigue(
+            [100, 110],
+            [5, 5],
+            [0, 1],
+            5,
+            [8, 8],
+        )
+        self.assertAlmostEqual(fatigue, 1091.75, places=2)
         tss = ExercisePrescription._calculate_exercise_tss([100.0], [5], [60], 120.0)
         self.assertAlmostEqual(tss, 1.157, places=3)
         stress = ExercisePrescription._stress_level([100, 110], [5, 5], [8, 8], [0, 1], 120.0, 10)

--- a/tools.py
+++ b/tools.py
@@ -1068,11 +1068,15 @@ class ExercisePrescription(MathTools):
         reps: list[int],
         timestamps: list[float],
         target_reps: int,
+        rpe_scores: list[float] | None = None,
     ) -> float:
         """Three-component fatigue model."""
         if not weights:
             return 0.0
         volumes = np.array(weights) * np.array(reps)
+        if rpe_scores is not None and len(rpe_scores) == len(volumes):
+            rpe_arr = np.array(rpe_scores)
+            volumes = volumes * (1 + (rpe_arr - 7) * 0.1)
         t_current = timestamps[-1] if timestamps else 0
         t_arr = np.array(timestamps)
         neu = np.sum(volumes * (ExercisePrescription.NEUROMUSCULAR_DECAY ** (t_current - t_arr)))
@@ -1402,7 +1406,13 @@ class ExercisePrescription(MathTools):
             ts_list[-1] if ts_list else 0,
         )
         target_reps_est = int(round(np.mean(reps))) if reps else 8
-        enhanced_fatigue = cls._enhanced_fatigue(weights, reps, ts_list, target_reps_est)
+        enhanced_fatigue = cls._enhanced_fatigue(
+            weights,
+            reps,
+            ts_list,
+            target_reps_est,
+            rpe_scores,
+        )
         tss_fatigue = cls._tss_adjusted_fatigue(
             weights,
             reps,


### PR DESCRIPTION
## Summary
- enhance fatigue model with optional RPE weighting
- pass RPE scores when calculating fatigue in exercise prescription
- update tests for new fatigue value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d311c06808327912913b01b8e4c4d