### PR TITLE
Extend long-term usage test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,3 +424,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Workouts can be labeled with user-defined tags managed via the settings tab. Tags must be assignable through REST endpoints and the Streamlit GUI.
 - All responsive layout and mobile-specific styling must be defined within the `_inject_responsive_css` method in `streamlit_app.py` and must preserve all desktop functionality.
 - Mobile CSS must support landscape orientation adjustments without removing any functionality.
+- The extended long term usage test must simulate at least six months (90 workouts) to verify long term stability.

--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ After installing the requirements you can run the automated tests with:
 pytest -q
 ```
 
-The tests exercise the entire REST API including machine learning features and a long‑term usage simulation.
+The tests exercise the entire REST API including machine learning features and a long‑term usage simulation covering six months of activity.
 Machine learning predictions may vary slightly; tests only validate value ranges.

--- a/tests/test_longterm_usage.py
+++ b/tests/test_longterm_usage.py
@@ -267,7 +267,7 @@ class ExtendedUsageTestCase(unittest.TestCase):
             os.remove(self.yaml_path)
 
     def test_extended_long_term_usage(self) -> None:
-        n = 60
+        n = 90
         start = datetime.date.today() - datetime.timedelta(days=n * 2 - 1)
         end = start + datetime.timedelta(days=n * 2 - 1)
 


### PR DESCRIPTION
## Summary
- update extended long term usage test to simulate six months of activity
- mention six month simulation in README
- note long term test requirement in AGENTS rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3d4f8cf883279a6e86ff06e2ebeb