### PR TITLE
Implement session duration analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,3 +425,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - All responsive layout and mobile-specific styling must be defined within the `_inject_responsive_css` method in `streamlit_app.py` and must preserve all desktop functionality.
 - Mobile CSS must support landscape orientation adjustments without removing any functionality.
 - The extended long term usage test must simulate at least six months (90 workouts) to verify long term stability.
+- Session duration analytics must calculate time between the first set start and last set finish per workout and be available via `/stats/session_duration`.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - All settings can be changed in the UI or by editing `settings.yaml` and remain synchronized.
 - Log daily wellness metrics like calories, sleep and stress and view summary statistics.
 - Calculate average rest times between sets via `/stats/rest_times`.
+- Measure total session duration via `/stats/session_duration`.
 - Analyze training intensity zones with `/stats/intensity_distribution`.
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.
 - Evaluate exercise frequency per week with `/stats/exercise_frequency`.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1117,6 +1117,13 @@ class GymAPI:
         ):
             return self.statistics.rest_times(start_date, end_date)
 
+        @self.app.get("/stats/session_duration")
+        def stats_session_duration(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.session_duration(start_date, end_date)
+
         @self.app.get("/stats/location_summary")
         def stats_location_summary(
             start_date: str = None,


### PR DESCRIPTION
## Summary
- add session duration rule to AGENTS
- expose /stats/session_duration endpoint
- compute session duration in StatisticsService
- document new endpoint in README
- test session duration via REST API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d41039c8c83279529d312c8a4f9e9