### PR TITLE
Enhance stats reporting in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Calculate average rest times between sets via `/stats/rest_times`.
 - Measure total session duration via `/stats/session_duration` and view results in the Reports tab.
 - Analyze training intensity zones with `/stats/intensity_distribution` displayed under Exercise Stats.
+- View velocity history per exercise with `/stats/velocity_history` and charts in the Stats tab.
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.
 - Summarize workouts by location with `/stats/location_summary` and view tables in the Reports tab.
 - Evaluate exercise frequency per week with `/stats/exercise_frequency`.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1706,6 +1706,15 @@ class GymApp:
                         {"1RM": [p["est_1rm"] for p in prog]},
                         x=[p["date"] for p in prog],
                     )
+                vel_hist = self.stats.velocity_history(
+                    ex_choice, start_str, end_str
+                )
+                if vel_hist:
+                    with st.expander("Velocity History", expanded=False):
+                        st.line_chart(
+                            {"Velocity": [v["velocity"] for v in vel_hist]},
+                            x=[v["date"] for v in vel_hist],
+                        )
                 self._progress_forecast_section(ex_choice)
             self._volume_forecast_section(start_str, end_str)
         with rec_tab:
@@ -1891,6 +1900,10 @@ class GymApp:
             duration = self.stats.session_duration(start_str, end_str)
             if duration:
                 st.table(duration)
+        with st.expander("Average Rest Times", expanded=False):
+            rests = self.stats.rest_times(start_str, end_str)
+            if rests:
+                st.table(rests)
         with st.expander("Location Summary", expanded=False):
             loc_stats = self.stats.location_summary(start_str, end_str)
             if loc_stats:


### PR DESCRIPTION
## Summary
- show velocity history in Exercise Stats progress tab
- display average rest time table in Reports
- document velocity analytics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dda59e79883279dfcc94ba0a607af