### PR TITLE
Improve small-screen layout

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -297,6 +297,20 @@ class GymApp:
                     font-size: 0.875rem;
                 }
             }
+            @media screen and (max-width: 320px) {
+                section.main > div {
+                    padding: 0.3rem !important;
+                }
+                h1 {
+                    font-size: 1.2rem;
+                }
+                h2 {
+                    font-size: 0.95rem;
+                }
+                h3 {
+                    font-size: 0.8rem;
+                }
+            }
             </style>
             """,
             unsafe_allow_html=True,

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -20,6 +20,8 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn("orientation: landscape", content)
         self.assertIn("textarea,", content)
         self.assertIn("Math.min", content)
+        self.assertIn("@media screen and (max-width: 320px)", content)
+        self.assertIn("font-size: 0.95rem;", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- refine mobile CSS for screens <=320px
- test that new CSS is included

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dedd4f7348327b209bf033eb1c987