### PR TITLE
Extend Streamlit app with calendar

### DIFF
--- a/db.py
+++ b/db.py
@@ -987,10 +987,21 @@ class PlannedWorkoutRepository(BaseRepository):
             (date, training_type),
         )
 
-    def fetch_all(self) -> List[Tuple[int, str, str]]:
-        return super().fetch_all(
-            "SELECT id, date, training_type FROM planned_workouts ORDER BY id DESC;"
-        )
+    def fetch_all(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Tuple[int, str, str]]:
+        query = "SELECT id, date, training_type FROM planned_workouts WHERE 1=1"
+        params: list[str] = []
+        if start_date:
+            query += " AND date >= ?"
+            params.append(start_date)
+        if end_date:
+            query += " AND date <= ?"
+            params.append(end_date)
+        query += " ORDER BY id DESC;"
+        return super().fetch_all(query, tuple(params))
 
     def fetch_detail(self, plan_id: int) -> Tuple[int, str, str]:
         rows = super().fetch_all(

--- a/rest_api.py
+++ b/rest_api.py
@@ -467,6 +467,32 @@ class GymAPI:
                 )
             return result
 
+        @self.app.get("/calendar")
+        def calendar(start_date: str, end_date: str):
+            logged = self.workouts.fetch_all_workouts(start_date, end_date)
+            planned = self.planned_workouts.fetch_all(start_date, end_date)
+            result = []
+            for wid, date, _s, _e, t_type, _notes, _rating in logged:
+                result.append(
+                    {
+                        "id": wid,
+                        "date": date,
+                        "training_type": t_type,
+                        "planned": False,
+                    }
+                )
+            for pid, date, t_type in planned:
+                result.append(
+                    {
+                        "id": pid,
+                        "date": date,
+                        "training_type": t_type,
+                        "planned": True,
+                    }
+                )
+            result.sort(key=lambda x: x["date"])
+            return result
+
         @self.app.get("/workouts/{workout_id}")
         def get_workout(workout_id: int):
             (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2217,3 +2217,23 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(stats["avg"], 4.5)
         self.assertEqual(stats["min"], 4)
         self.assertEqual(stats["max"], 5)
+
+    def test_calendar_endpoint(self) -> None:
+        today = datetime.date.today().isoformat()
+        tomorrow = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
+        self.client.post("/workouts", params={"date": today})
+        self.client.post(
+            "/planned_workouts",
+            params={"date": tomorrow, "training_type": "strength"},
+        )
+        resp = self.client.get(
+            "/calendar",
+            params={"start_date": today, "end_date": tomorrow},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["date"], today)
+        self.assertFalse(data[0]["planned"])
+        self.assertEqual(data[1]["date"], tomorrow)
+        self.assertTrue(data[1]["planned"])


### PR DESCRIPTION
## Summary
- allow fetching planned workouts by date range
- add `/calendar` API endpoint merging logged and planned workouts
- provide Calendar tab in the Streamlit GUI
- test the new calendar endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dffe019508327abc22b89132d1c89