### PR TITLE
Require exercise when creating goals

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -1514,6 +1514,7 @@ class GymAPI:
             return [
                 {
                     "id": gid,
+                    "exercise_name": ex,
                     "name": name,
                     "target_value": val,
                     "unit": unit,
@@ -1521,23 +1522,29 @@ class GymAPI:
                     "target_date": target,
                     "achieved": bool(ach),
                 }
-                for gid, name, val, unit, start, target, ach in rows
+                for gid, ex, name, val, unit, start, target, ach in rows
             ]
 
         @self.app.post("/goals")
         def add_goal(
+            exercise_name: str,
             name: str,
             target_value: float,
             unit: str,
             start_date: str,
             target_date: str,
         ):
-            gid = self.goals.add(name, target_value, unit, start_date, target_date)
+            if not exercise_name:
+                raise HTTPException(status_code=400, detail="exercise required")
+            gid = self.goals.add(
+                exercise_name, name, target_value, unit, start_date, target_date
+            )
             return {"id": gid}
 
         @self.app.put("/goals/{goal_id}")
         def update_goal(
             goal_id: int,
+            exercise_name: str | None = None,
             name: str | None = None,
             target_value: float | None = None,
             unit: str | None = None,
@@ -1548,6 +1555,7 @@ class GymAPI:
             try:
                 self.goals.update(
                     goal_id,
+                    exercise_name,
                     name,
                     target_value,
                     unit,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2307,14 +2307,17 @@ class GymApp:
     def _goals_tab(self) -> None:
         st.header("Goals")
         with st.expander("Add Goal"):
+            ex_names = [""] + self.exercise_names_repo.fetch_all()
+            ex_choice = st.selectbox("Exercise", ex_names, key="goal_ex")
             name = st.text_input("Name", key="goal_name")
             value = st.number_input("Target Value", min_value=0.0, step=0.1, key="goal_value")
             unit = st.text_input("Unit", key="goal_unit")
             start_d = st.date_input("Start Date", datetime.date.today(), key="goal_start")
             target_d = st.date_input("Target Date", datetime.date.today(), key="goal_target")
             if st.button("Create Goal", key="goal_add"):
-                if name and unit:
+                if name and unit and ex_choice:
                     self.goals_repo.add(
+                        ex_choice,
                         name,
                         float(value),
                         unit,
@@ -2323,12 +2326,19 @@ class GymApp:
                     )
                     st.success("Added")
                 else:
-                    st.warning("Name and unit required")
+                    st.warning("Exercise, name and unit required")
         with st.expander("Existing Goals", expanded=True):
             rows = self.goals_repo.fetch_all()
-            for gid, gname, gval, gunit, sdate, tdate, ach in rows:
+            for gid, exn, gname, gval, gunit, sdate, tdate, ach in rows:
                 exp = st.expander(f"{gname} - {gval}{gunit}")
                 with exp:
+                    names = self.exercise_names_repo.fetch_all()
+                    ex_e = st.selectbox(
+                        "Exercise",
+                        names,
+                        index=names.index(exn),
+                        key=f"goal_ex_{gid}",
+                    )
                     name_e = st.text_input("Name", gname, key=f"goal_name_{gid}")
                     val_e = st.number_input(
                         "Target Value",
@@ -2352,6 +2362,7 @@ class GymApp:
                     if cols[0].button("Update", key=f"goal_upd_{gid}"):
                         self.goals_repo.update(
                             gid,
+                            ex_e,
                             name_e,
                             float(val_e),
                             unit_e,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2245,6 +2245,7 @@ class APITestCase(unittest.TestCase):
         resp = self.client.post(
             "/goals",
             params={
+                "exercise_name": "Squat",
                 "name": "Squat PR",
                 "target_value": 200.0,
                 "unit": "kg",
@@ -2260,6 +2261,7 @@ class APITestCase(unittest.TestCase):
         data = resp.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["name"], "Squat PR")
+        self.assertEqual(data[0]["exercise_name"], "Squat")
 
         resp = self.client.put(
             f"/goals/{gid}",


### PR DESCRIPTION
## Summary
- link goals to exercises in the database
- extend goal repository to handle exercise names
- update API endpoints and Streamlit GUI to enforce exercise selection
- adjust tests for new goal behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e07ae0dc08327a25d97d8048a2e43