### PR TITLE
Enhance mobile GUI navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,3 +426,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Mobile CSS must support landscape orientation adjustments without removing any functionality.
 - The extended long term usage test must simulate at least six months (90 workouts) to verify long term stability.
 - Session duration analytics must calculate time between the first set start and last set finish per workout and be available via `/stats/session_duration`.
+- Bottom navigation markup must not include CSS; its styling belongs in `_inject_responsive_css` only.

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -22,6 +22,7 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn("Math.min", content)
         self.assertIn("@media screen and (max-width: 320px)", content)
         self.assertIn("font-size: 0.95rem;", content)
+        self.assertIn(".bottom-nav", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add bottom navigation bar for mobile devices
- style mobile navigation via responsive CSS
- route mobile tab changes via query params
- update mobile CSS tests
- document rule about bottom nav styling in `AGENTS.md`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e19e35c88832780c70f0eb3fb5955