### PR TITLE
Add time under tension analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Log daily wellness metrics like calories, sleep and stress and view summary statistics.
 - Calculate average rest times between sets via `/stats/rest_times`.
 - Measure total session duration via `/stats/session_duration` and view results in the Reports tab.
+- Calculate total time under tension per workout via `/stats/time_under_tension`.
 - Analyze training intensity zones with `/stats/intensity_distribution` displayed under Exercise Stats.
 - View velocity history per exercise with `/stats/velocity_history` and charts in the Stats tab.
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1166,6 +1166,13 @@ class GymAPI:
         ):
             return self.statistics.session_duration(start_date, end_date)
 
+        @self.app.get("/stats/time_under_tension")
+        def stats_time_under_tension(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.time_under_tension(start_date, end_date)
+
         @self.app.get("/stats/location_summary")
         def stats_location_summary(
             start_date: str = None,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2145,6 +2145,14 @@ class GymApp:
                     {"Rest": [r["avg_rest"] for r in rests]},
                     x=[str(r["workout_id"]) for r in rests],
                 )
+        with st.expander("Time Under Tension", expanded=False):
+            tut = self.stats.time_under_tension(start_str, end_str)
+            if tut:
+                st.table(tut)
+                st.line_chart(
+                    {"TUT": [t["tut"] for t in tut]},
+                    x=[t["date"] for t in tut],
+                )
         with st.expander("Location Summary", expanded=False):
             loc_stats = self.stats.location_summary(start_str, end_str)
             if loc_stats:


### PR DESCRIPTION
## Summary
- implement time_under_tension calculation in `StatisticsService`
- expose `/stats/time_under_tension` in REST API
- display time under tension charts in the Reports tab
- test new endpoint
- document feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e285345ac8327a6cd14e568b0712c