### PR TITLE
Improve stats GUI with set pace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,3 +427,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - The extended long term usage test must simulate at least six months (90 workouts) to verify long term stability.
 - Session duration analytics must calculate time between the first set start and last set finish per workout and be available via `/stats/session_duration`.
 - Bottom navigation markup must not include CSS; its styling belongs in `_inject_responsive_css` only.
+- Set pace analytics must compute sets per minute per workout and be available via `/stats/set_pace`.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1152,6 +1152,13 @@ class GymAPI:
         ):
             return self.statistics.session_density(start_date, end_date)
 
+        @self.app.get("/stats/set_pace")
+        def stats_set_pace(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.set_pace(start_date, end_date)
+
         @self.app.get("/stats/rest_times")
         def stats_rest_times(
             start_date: str = None,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2137,6 +2137,14 @@ class GymApp:
                     {"Density": [d["density"] for d in density]},
                     x=[d["date"] for d in density],
                 )
+        with st.expander("Set Pace", expanded=False):
+            pace = self.stats.set_pace(start_str, end_str)
+            if pace:
+                st.table(pace)
+                st.line_chart(
+                    {"Pace": [p["pace"] for p in pace]},
+                    x=[p["date"] for p in pace],
+                )
         with st.expander("Average Rest Times", expanded=False):
             rests = self.stats.rest_times(start_str, end_str)
             if rests:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -64,6 +64,10 @@ class MathToolsTestCase(unittest.TestCase):
         val = MathTools.session_density(1000.0, 600)
         self.assertAlmostEqual(val, 100.0)
 
+    def test_set_pace(self) -> None:
+        pace = MathTools.set_pace(30, 900)
+        self.assertAlmostEqual(pace, 2.0)
+
     def test_sleep_recovery_index(self) -> None:
         sf = ExercisePrescription._sleep_factor(7)
         psqf = ExercisePrescription._perceived_sleep_quality_factor(4)

--- a/tools.py
+++ b/tools.py
@@ -116,6 +116,13 @@ class MathTools:
             return 0.0
         return volume / (duration_seconds / 60)
 
+    @staticmethod
+    def set_pace(sets: int, duration_seconds: float) -> float:
+        """Return sets completed per minute."""
+        if duration_seconds <= 0:
+            return 0.0
+        return sets / (duration_seconds / 60)
+
 
     @staticmethod
     def overtraining_index(stress: float, fatigue: float, variability: float) -> float:


### PR DESCRIPTION
## Summary
- add `set_pace` calculation in `MathTools`
- provide `set_pace` analytics in `StatisticsService` and REST API
- expose set pace metrics in the reports tab
- update tests for new analytics
- document rule for set pace analytics

## Testing
- `pytest tests/test_tools.py::MathToolsTestCase::test_set_pace -q`
- `pytest tests/test_api.py::APITestCase::test_set_pace_endpoint -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2d7ebdc48327878488e80d5e96f5