### PR TITLE
Improve stats with exercise diversity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Calculate average rest times between sets via `/stats/rest_times`.
 - Measure total session duration via `/stats/session_duration` and view results in the Reports tab.
 - Calculate total time under tension per workout via `/stats/time_under_tension`.
+- Assess workout variety with `/stats/exercise_diversity` and charts in the Reports tab.
 - Analyze training intensity zones with `/stats/intensity_distribution` displayed under Exercise Stats.
 - View velocity history per exercise with `/stats/velocity_history` and charts in the Stats tab.
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1180,6 +1180,13 @@ class GymAPI:
         ):
             return self.statistics.time_under_tension(start_date, end_date)
 
+        @self.app.get("/stats/exercise_diversity")
+        def stats_exercise_diversity(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.exercise_diversity(start_date, end_date)
+
         @self.app.get("/stats/location_summary")
         def stats_location_summary(
             start_date: str = None,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2153,6 +2153,14 @@ class GymApp:
                     {"Rest": [r["avg_rest"] for r in rests]},
                     x=[str(r["workout_id"]) for r in rests],
                 )
+        with st.expander("Exercise Diversity", expanded=False):
+            div = self.stats.exercise_diversity(start_str, end_str)
+            if div:
+                st.table(div)
+                st.line_chart(
+                    {"Diversity": [d["diversity"] for d in div]},
+                    x=[d["date"] for d in div],
+                )
         with st.expander("Time Under Tension", expanded=False):
             tut = self.stats.time_under_tension(start_str, end_str)
             if tut:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1503,6 +1503,25 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(data[0]["workout_id"], 1)
         self.assertAlmostEqual(data[0]["tut"], 10.0, places=2)
 
+    def test_exercise_diversity_endpoint(self) -> None:
+        self.client.post("/workouts")
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Squat", "equipment": "Olympic Barbell"},
+        )
+        self.client.post("/exercises/1/sets", params={"reps": 5, "weight": 100.0, "rpe": 8})
+        self.client.post("/exercises/2/sets", params={"reps": 5, "weight": 100.0, "rpe": 8})
+        resp = self.client.get("/stats/exercise_diversity")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["workout_id"], 1)
+        self.assertAlmostEqual(data[0]["diversity"], 1.0, places=2)
+
     def test_location_summary_endpoint(self) -> None:
         self.client.post(
             "/workouts",

--- a/tools.py
+++ b/tools.py
@@ -123,6 +123,19 @@ class MathTools:
             return 0.0
         return sets / (duration_seconds / 60)
 
+    @staticmethod
+    def diversity_index(counts: Iterable[int]) -> float:
+        """Return Shannon diversity index for ``counts``."""
+        total = sum(counts)
+        if total <= 0:
+            return 0.0
+        ent = 0.0
+        for c in counts:
+            if c > 0:
+                p = c / total
+                ent -= p * math.log(p, 2)
+        return ent
+
 
     @staticmethod
     def overtraining_index(stress: float, fatigue: float, variability: float) -> float:


### PR DESCRIPTION
## Summary
- add diversity_index utility
- analyze exercise diversity per workout
- expose new `/stats/exercise_diversity` endpoint
- display exercise diversity in Reports tab
- document and test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e333db73883278935b3ceb09444f5