### PR TITLE
Improve Streamlit GUI with consistency metric

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,3 +428,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Session duration analytics must calculate time between the first set start and last set finish per workout and be available via `/stats/session_duration`.
 - Bottom navigation markup must not include CSS; its styling belongs in `_inject_responsive_css` only.
 - Set pace analytics must compute sets per minute per workout and be available via `/stats/set_pace`.
+- Workout consistency analytics must compute the coefficient of variation of days between workouts and be available via `/stats/workout_consistency`.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.
 - Summarize workouts by location with `/stats/location_summary` and view tables in the Reports tab.
 - Evaluate exercise frequency per week with `/stats/exercise_frequency`.
+- Evaluate workout schedule consistency with `/stats/workout_consistency` displayed in Reports.
 - Analyze week-over-week volume change with `/stats/weekly_volume_change` displayed in the Reports tab.
 - Track body weight over time using `/body_weight` endpoints and `/stats/weight_stats`.
 - Forecast future body weight trends with `/stats/weight_forecast`.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1194,6 +1194,13 @@ class GymAPI:
         ):
             return self.statistics.location_summary(start_date, end_date)
 
+        @self.app.get("/stats/workout_consistency")
+        def stats_workout_consistency(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.workout_consistency(start_date, end_date)
+
         @self.app.get("/stats/volume_forecast")
         def stats_volume_forecast(
             days: int = 7,

--- a/stats_service.py
+++ b/stats_service.py
@@ -1624,3 +1624,21 @@ class StatisticsService:
             freq = len(by_name[name]) / weeks if weeks > 0 else 0.0
             result.append({"exercise": name, "frequency_per_week": round(freq, 2)})
         return result
+
+    def workout_consistency(
+        self,
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> dict[str, float]:
+        """Return coefficient of variation of workout intervals."""
+        if self.workouts is None:
+            return {"consistency": 0.0, "average_gap": 0.0}
+        rows = self.workouts.fetch_all_workouts(start_date, end_date)
+        dates = [datetime.date.fromisoformat(d) for _id, d, *_ in rows]
+        if len(dates) < 2:
+            return {"consistency": 0.0, "average_gap": 0.0}
+        dates.sort()
+        gaps = [(b - a).days for a, b in zip(dates[:-1], dates[1:])]
+        avg_gap = sum(gaps) / len(gaps)
+        cv = MathTools.coefficient_of_variation(gaps)
+        return {"consistency": round(cv, 2), "average_gap": round(avg_gap, 2)}

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2173,6 +2173,10 @@ class GymApp:
             loc_stats = self.stats.location_summary(start_str, end_str)
             if loc_stats:
                 st.table(loc_stats)
+        with st.expander("Workout Consistency", expanded=False):
+            consistency = self.stats.workout_consistency(start_str, end_str)
+            st.metric("Consistency", consistency["consistency"])
+            st.metric("Avg Gap (days)", consistency["average_gap"])
         with st.expander("Rating Analysis", expanded=False):
             rating_hist = self.stats.rating_history(start_str, end_str)
             if rating_hist:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2473,3 +2473,16 @@ class APITestCase(unittest.TestCase):
         data = rec.json()
         self.assertIn("weight", data)
         self.assertIn("reps", data)
+
+    def test_workout_consistency_endpoint(self) -> None:
+        d0 = datetime.date.today() - datetime.timedelta(days=14)
+        d1 = datetime.date.today() - datetime.timedelta(days=7)
+        d2 = datetime.date.today()
+        for d in [d0, d1, d2]:
+            self.client.post("/workouts", params={"date": d.isoformat()})
+
+        resp = self.client.get("/stats/workout_consistency")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertAlmostEqual(data["consistency"], 0.0)
+        self.assertAlmostEqual(data["average_gap"], 7.0)

--- a/tools.py
+++ b/tools.py
@@ -136,6 +136,19 @@ class MathTools:
                 ent -= p * math.log(p, 2)
         return ent
 
+    @staticmethod
+    def coefficient_of_variation(values: Iterable[float]) -> float:
+        """Return the coefficient of variation for ``values``."""
+        data = list(values)
+        if len(data) < 2:
+            return 0.0
+        arr = np.array(data, dtype=float)
+        mean = float(np.mean(arr))
+        if mean == 0:
+            return 0.0
+        std = float(np.std(arr))
+        return std / mean
+
 
     @staticmethod
     def overtraining_index(stress: float, fatigue: float, variability: float) -> float:


### PR DESCRIPTION
## Summary
- add `coefficient_of_variation` utility
- implement `workout_consistency` analytics
- expose `/stats/workout_consistency` endpoint
- display workout consistency in Reports tab
- document new endpoint in README
- add rule in AGENTS and corresponding API test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e35c4337883278123747ab712989c