### PR TITLE
Improve Streamlit layout responsiveness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,3 +430,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Metrics displayed in the GUI must be wrapped in a container using the `metric-grid` CSS class for consistent responsive layout.
 - Set pace analytics must compute sets per minute per workout and be available via `/stats/set_pace`.
 - Workout consistency analytics must compute the coefficient of variation of days between workouts and be available via `/stats/workout_consistency`.
+- Mobile layout must use a `--vh` CSS variable set via JavaScript in `_configure_page` for reliable viewport height across orientations.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -169,8 +169,16 @@ class GymApp:
                     window.location.search = params.toString();
                 }
             }
-            window.addEventListener('resize', setMode);
-            window.addEventListener('orientationchange', setMode);
+            function setVh() {
+                document.documentElement.style.setProperty('--vh', `${window.innerHeight * 0.01}px`);
+            }
+            function handleResize() {
+                setMode();
+                setVh();
+            }
+            window.addEventListener('resize', handleResize);
+            window.addEventListener('orientationchange', handleResize);
+            setVh();
             </script>
             """,
             height=0,
@@ -187,7 +195,7 @@ class GymApp:
                 padding: 0;
                 box-sizing: border-box;
                 scroll-behavior: smooth;
-                min-height: 100vh;
+                min-height: calc(var(--vh, 1vh) * 100);
                 display: flex;
                 flex-direction: column;
             }
@@ -506,6 +514,7 @@ class GymApp:
                 display: grid;
                 grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
                 gap: 0.5rem;
+                justify-items: center;
                 overflow-x: auto;
                 padding: 0.25rem;
             }


### PR DESCRIPTION
## Summary
- refine `_configure_page` JS to update CSS variable `--vh`
- use `--vh` for reliable viewport height
- center metrics in `metric-grid`
- document new viewport rule in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7d72f21c832799882b357805d3e1