### PR TITLE
Improve Streamlit layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 ## Features
 
 - Fully responsive Streamlit interface with automatic layout detection for desktop and mobile devices, including orientation-aware layouts.
+- Improved metric grid and navigation styling ensure full compatibility on small screens.
 - Mobile layouts stack columns vertically, resize charts and provide horizontal scrolling for wide tables.
 - Desktop mode features a sticky top navigation bar for quick access to main tabs.
 - REST API exposing every action used by the GUI.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -409,6 +409,9 @@ class GymApp:
                 nav.bottom-nav button {
                     flex: 1 0 25%;
                 }
+                nav.bottom-nav .label {
+                    display: none;
+                }
             }
             @media screen and (max-width: 320px) and (orientation: landscape) {
                 .content-wrapper {
@@ -456,6 +459,9 @@ class GymApp:
                 }
                 nav.bottom-nav button {
                     flex: 1 0 33%;
+                }
+                .metric-grid {
+                    grid-template-columns: repeat(2, 1fr);
                 }
             }
             @media screen and (max-width: 768px) {
@@ -662,6 +668,11 @@ class GymApp:
                     padding: 1.25rem;
                 }
             }
+            @media screen and (min-width: 1500px) {
+                .content-wrapper {
+                    max-width: 1400px;
+                }
+            }
             button {
                 padding: 0.5rem 0.75rem;
             }
@@ -806,11 +817,9 @@ class GymApp:
 
     def _metric_grid(self, metrics: list[tuple[str, str]]) -> None:
         """Render metrics in a responsive grid."""
-        col_num = 2 if st.session_state.is_mobile else 4
         st.markdown("<div class='metric-grid'>", unsafe_allow_html=True)
-        cols = st.columns(col_num, gap="small")
-        for idx, (label, val) in enumerate(metrics):
-            cols[idx % col_num].metric(label, val)
+        for label, val in metrics:
+            st.metric(label, val)
         st.markdown("</div>", unsafe_allow_html=True)
 
     @contextmanager


### PR DESCRIPTION
## Summary
- simplify metric grid logic so CSS controls layout
- tweak mobile bottom nav labels and metric grid breakpoints
- widen content on very large screens
- update README about metric grid improvements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea46d0f5c8327b227c4fd03369c49