### PR TITLE
Improve Streamlit layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 
 - Fully responsive Streamlit interface with automatic layout detection for desktop and mobile devices, including orientation-aware layouts.
 - Improved metric grid and navigation styling ensure full compatibility on small screens.
+- Additional grid breakpoints enhance layout on very large and ultra-wide displays.
 - Mobile layouts stack columns vertically, resize charts and provide horizontal scrolling for wide tables.
 - Desktop mode features a sticky top navigation bar for quick access to main tabs.
 - REST API exposing every action used by the GUI.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -673,6 +673,22 @@ class GymApp:
                     max-width: 1400px;
                 }
             }
+            @media screen and (min-width: 1500px) {
+                .metric-grid {
+                    grid-template-columns: repeat(5, 1fr);
+                }
+                .form-grid {
+                    grid-template-columns: repeat(3, 1fr);
+                }
+            }
+            @media screen and (min-width: 1800px) {
+                .metric-grid {
+                    grid-template-columns: repeat(6, 1fr);
+                }
+                .form-grid {
+                    grid-template-columns: repeat(4, 1fr);
+                }
+            }
             button {
                 padding: 0.5rem 0.75rem;
             }

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -23,6 +23,8 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn("@media screen and (max-width: 320px)", content)
         self.assertIn("font-size: 0.95rem;", content)
         self.assertIn(".bottom-nav", content)
+        self.assertIn("repeat(5, 1fr)", content)
+        self.assertIn("repeat(6, 1fr)", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- tweak README features section
- expand responsive CSS rules to support ultra-wide layouts
- check new CSS breakpoints in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea83c829483278d75f5f1322a2801