### PR TITLE
Expand Streamlit GUI tests

### DIFF
--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,33 +1,72 @@
 import os
+import sys
 import sqlite3
+import unittest
 from streamlit.testing.v1 import AppTest
 
-def test_streamlit_workflow(tmp_path):
-    db_path = tmp_path / "test.db"
-    yaml_path = tmp_path / "settings.yaml"
-    os.environ["DB_PATH"] = str(db_path)
-    os.environ["YAML_PATH"] = str(yaml_path)
-    os.environ["TEST_MODE"] = "1"
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-    at = AppTest.from_file("streamlit_app.py", default_timeout=20)
-    at.query_params["mode"] = "desktop"
-    at.query_params["tab"] = "workouts"
-    at.run(timeout=20)
 
-    at.button[1].click().run()
-    at.selectbox[3].select("Barbell Bench Press").run()
-    at.selectbox[5].select("Olympic Barbell").run()
-    at.button[9].click().run()
-    at.number_input[0].set_value(5).run()
-    at.number_input[1].set_value(100.0).run()
-    at.button[13].click().run()
+class StreamlitAppTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db_path = "test_gui.db"
+        self.yaml_path = "test_gui_settings.yaml"
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        if os.path.exists(self.yaml_path):
+            os.remove(self.yaml_path)
+        os.environ["DB_PATH"] = self.db_path
+        os.environ["YAML_PATH"] = self.yaml_path
+        os.environ["TEST_MODE"] = "1"
+        self.at = AppTest.from_file("streamlit_app.py", default_timeout=20)
+        self.at.query_params["mode"] = "desktop"
+        self.at.query_params["tab"] = "workouts"
+        self.at.run(timeout=20)
 
-    conn = sqlite3.connect(db_path)
-    cur = conn.cursor()
-    cur.execute("SELECT COUNT(*) FROM workouts;")
-    assert cur.fetchone()[0] == 1
-    cur.execute("SELECT name FROM exercises;")
-    assert cur.fetchone()[0] == "Barbell Bench Press"
-    cur.execute("SELECT reps, weight FROM sets;")
-    assert cur.fetchone() == (5, 100.0)
-    conn.close()
+    def tearDown(self) -> None:
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        if os.path.exists(self.yaml_path):
+            os.remove(self.yaml_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.db_path)
+
+    def test_add_workout_and_set(self) -> None:
+        self.at.button[1].click().run()
+        self.at.selectbox[3].select("Barbell Bench Press").run()
+        self.at.selectbox[5].select("Olympic Barbell").run()
+        self.at.button[9].click().run()
+        self.at.number_input[0].set_value(5).run()
+        self.at.number_input[1].set_value(100.0).run()
+        self.at.button[13].click().run()
+
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM workouts;")
+        self.assertEqual(cur.fetchone()[0], 1)
+        cur.execute("SELECT name FROM exercises;")
+        self.assertEqual(cur.fetchone()[0], "Barbell Bench Press")
+        cur.execute("SELECT reps, weight FROM sets;")
+        self.assertEqual(cur.fetchone(), (5, 100.0))
+        conn.close()
+
+    def test_workout_metadata(self) -> None:
+        self.at.button[1].click().run()
+        self.at.text_input[1].input("Home").run()
+        self.at.button[6].click().run()
+        self.at.button[2].click().run()
+        self.at.button[3].click().run()
+
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT location, start_time, end_time FROM workouts;")
+        location, start_time, end_time = cur.fetchone()
+        self.assertEqual(location, "Home")
+        self.assertIsNotNone(start_time)
+        self.assertIsNotNone(end_time)
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert streamlit GUI test into `unittest.TestCase`
- verify workout metadata and add set workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f33d987008327881a5085a23293e6