### PR TITLE
Expand GUI tests, remove deprecated API usage

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -136,8 +136,8 @@ class GymApp:
     def _configure_page(self) -> None:
         if st.session_state.get("layout_set"):
             return
-        params = st.experimental_get_query_params()
-        mode = params.get("mode", [None])[0]
+        params = st.query_params
+        mode = params.get("mode")
         if mode is None:
             st.components.v1.html(
                 """
@@ -863,7 +863,7 @@ class GymApp:
 
     def _switch_tab(self, label: str) -> None:
         mode = "mobile" if st.session_state.is_mobile else "desktop"
-        st.experimental_set_query_params(mode=mode, tab=label)
+        st.query_params.update({"mode": mode, "tab": label})
         st.experimental_rerun()
 
     def _metric_grid(self, metrics: list[tuple[str, str]]) -> None:
@@ -1042,8 +1042,8 @@ class GymApp:
                         st.table(top_ex[:5])
 
     def run(self) -> None:
-        params = st.experimental_get_query_params()
-        tab_param = params.get("tab", [None])[0]
+        params = st.query_params
+        tab_param = params.get("tab")
         tab_map = {
             "workouts": 0,
             "library": 1,

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -67,6 +67,23 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertIsNotNone(end_time)
         conn.close()
 
+    def test_plan_to_workout(self) -> None:
+        self.at.date_input[0].set_value("2024-01-02").run()
+        self.at.selectbox[0].select("strength").run()
+        self.at.button[4].click().run()
+        self.at.run()
+        self.at.selectbox[0].select("1").run()
+        self.at.button[1].click().run()
+
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM planned_workouts;")
+        self.assertEqual(cur.fetchone()[0], 1)
+        cur.execute("SELECT date, training_type FROM workouts;")
+        row = cur.fetchone()
+        self.assertEqual(row, ("2024-01-02", "strength"))
+        conn.close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- switch to `st.query_params` API
- use `st.query_params.update` when switching tabs
- add a GUI test covering planned workout conversion

## Testing
- `pytest -k "streamlit_app or mobile_css" -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3de3c0e0832798ffde6ba165e2fd