### PR TITLE
Improve GUI tests and chart handling

### DIFF
--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -4,6 +4,7 @@ import sqlite3
 import unittest
 import warnings
 from altair.utils.deprecation import AltairDeprecationWarning
+import yaml
 
 warnings.simplefilter("ignore", AltairDeprecationWarning)
 
@@ -175,6 +176,15 @@ class StreamlitAppTest(unittest.TestCase):
         cur.execute("SELECT name FROM tags;")
         self.assertEqual(cur.fetchone()[0], "morning")
         conn.close()
+
+    def test_toggle_theme_button(self) -> None:
+        for btn in self.at.button:
+            if btn.label == "Toggle Theme":
+                btn.click().run()
+                break
+        with open(self.yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        self.assertEqual(data["theme"], "dark")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch from `st.experimental_rerun` to `st.rerun`
- add helper methods `_line_chart` and `_bar_chart`
- use helpers in stats tabs to avoid single-point errors
- add GUI test for theme toggle

## Testing
- `pytest -q tests/test_streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687f51f99a648327927cfd5c5e0de8a8