### PR TITLE
Update requirements to include altair

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pywavelets
 scikit-learn
 torch
 pyyaml
+altair


### PR DESCRIPTION
## Summary
- add missing `altair` package to requirements
- verify installation and run tests

## Testing
- `pip install -r requirements.txt --break-system-packages`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f911f750c8327b130a83f47c35a6d