### PR TITLE
Fix streamlit blank screen on startup

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -166,7 +166,7 @@ class GymApp:
                 """,
                 height=0,
             )
-            st.stop()
+            mode = "desktop"
         layout = "centered" if mode == "mobile" else "wide"
         st.set_page_config(page_title="Workout Logger", layout=layout)
         st.markdown(


### PR DESCRIPTION
## Summary
- avoid stopping app when `mode` query param missing
- default to desktop mode if detection script fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9a907e108327870c6bdc7394c8ce