### PR TITLE
Enhance mobile layout responsiveness

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -545,6 +545,14 @@ class GymApp:
                     font-size: 0.8rem;
                 }
             }
+            @media screen and (max-width: 375px) and (orientation: portrait) {
+                nav.bottom-nav button {
+                    font-size: 0.65rem;
+                }
+                nav.bottom-nav .icon {
+                    font-size: 1.1rem;
+                }
+            }
             @media screen and (max-width: 600px) and (orientation: landscape) {
                 nav.bottom-nav button {
                     font-size: 0.7rem;
@@ -630,6 +638,11 @@ class GymApp:
             }
             nav.top-nav .label {
                 font-size: 0.9rem;
+            }
+            @media screen and (max-width: 375px) {
+                nav.top-nav .label {
+                    font-size: 0.75rem;
+                }
             }
             @media screen and (min-width: 769px) {
                 nav.top-nav button {

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -25,6 +25,11 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn(".bottom-nav", content)
         self.assertIn("repeat(5, 1fr)", content)
         self.assertIn("repeat(6, 1fr)", content)
+        self.assertIn(
+            "@media screen and (max-width: 375px) and (orientation: portrait)",
+            content,
+        )
+        self.assertIn("font-size: 0.65rem;", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- tweak bottom navigation font sizing for narrow portrait devices
- adjust top navigation label size for very small screens
- validate new CSS with updated GUI tests

## Testing
- `pytest tests/test_mobile_css.py::MobileCSSTest::test_css_rules_present -q`
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_add_workout_and_set -q`
- `pytest tests/test_streamlit_app.py tests/test_mobile_css.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687fba373b4c832794b3c75001957a73