### PR TITLE
Improve responsive layout with scroll-top button

### DIFF
--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -30,6 +30,7 @@ class MobileCSSTest(unittest.TestCase):
             content,
         )
         self.assertIn("font-size: 0.65rem;", content)
+        self.assertIn(".scroll-top", content)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -453,6 +453,14 @@ class StreamlitAdditionalGUITest(unittest.TestCase):
         )
         self.assertTrue(nav_present)
 
+    def test_scroll_top_button(self) -> None:
+        self.at.query_params["mode"] = "mobile"
+        self.at.run()
+        btn_present = any(
+            "scroll-top" in m.body for m in self.at.markdown
+        )
+        self.assertTrue(btn_present)
+
 
 class StreamlitTemplateWorkflowTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
- add responsive scroll-top button to the GUI
- inject new CSS and JavaScript for mobile compatibility
- suppress Altair deprecation warnings globally
- test presence of scroll-top button and CSS rule

## Testing
- `pytest tests/test_streamlit_app.py tests/test_mobile_css.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc5fe5b248327bcc9864797edbb5f