### PR TITLE
Improve metric layout styling

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -700,6 +700,12 @@ class GymApp:
             .metric-grid > div[data-testid="metric-container"] {
                 width: 100%;
             }
+            .metric-card {
+                background: var(--section-bg);
+                border-radius: 0.5rem;
+                padding: 0.5rem;
+                box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            }
             .metric-grid::-webkit-scrollbar {
                 display: none;
             }
@@ -968,7 +974,9 @@ class GymApp:
         """Render metrics in a responsive grid."""
         st.markdown("<div class='metric-grid'>", unsafe_allow_html=True)
         for label, val in metrics:
+            st.markdown("<div class='metric-card'>", unsafe_allow_html=True)
             st.metric(label, val)
+            st.markdown("</div>", unsafe_allow_html=True)
         st.markdown("</div>", unsafe_allow_html=True)
 
     def _line_chart(self, data: dict[str, list], x: list[str]) -> None:

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -31,6 +31,7 @@ class MobileCSSTest(unittest.TestCase):
         )
         self.assertIn("font-size: 0.65rem;", content)
         self.assertIn(".scroll-top", content)
+        self.assertIn(".metric-card", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- wrap each metric in a `.metric-card` container for better layout
- style `.metric-card` in responsive CSS
- check for `.metric-card` style in GUI tests

## Testing
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_add_workout_and_set tests/test_mobile_css.py::MobileCSSTest::test_css_rules_present -q`

------
https://chatgpt.com/codex/tasks/task_e_688003cce1748327ab4a94b38e2f68fb