### PR TITLE
Add ability to hide preconfigured equipment

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -59,7 +59,8 @@ class GymAPI:
         self.template_workouts = TemplateWorkoutRepository(db_path)
         self.template_exercises = TemplateExerciseRepository(db_path)
         self.template_sets = TemplateSetRepository(db_path)
-        self.equipment = EquipmentRepository(db_path)
+        self.settings = SettingsRepository(db_path, yaml_path)
+        self.equipment = EquipmentRepository(db_path, self.settings)
         self.exercise_catalog = ExerciseCatalogRepository(db_path)
         self.muscles = MuscleRepository(db_path)
         self.exercise_names = ExerciseNameRepository(db_path)
@@ -67,7 +68,6 @@ class GymAPI:
         self.favorite_templates = FavoriteTemplateRepository(db_path)
         self.favorite_workouts = FavoriteWorkoutRepository(db_path)
         self.tags = TagRepository(db_path)
-        self.settings = SettingsRepository(db_path, yaml_path)
         self.pyramid_tests = PyramidTestRepository(db_path)
         self.pyramid_entries = PyramidEntryRepository(db_path)
         self.game_repo = GamificationRepository(db_path)
@@ -1682,6 +1682,7 @@ class GymAPI:
             ml_goal_prediction_enabled: bool = None,
             ml_injury_training_enabled: bool = None,
             ml_injury_prediction_enabled: bool = None,
+            hide_preconfigured_equipment: bool = None,
         ):
             if body_weight is not None:
                 self.settings.set_float("body_weight", body_weight)
@@ -1744,6 +1745,10 @@ class GymAPI:
             if ml_injury_prediction_enabled is not None:
                 self.settings.set_bool(
                     "ml_injury_prediction_enabled", ml_injury_prediction_enabled
+                )
+            if hide_preconfigured_equipment is not None:
+                self.settings.set_bool(
+                    "hide_preconfigured_equipment", hide_preconfigured_equipment
                 )
             return {"status": "updated"}
 

--- a/stats_service.py
+++ b/stats_service.py
@@ -361,6 +361,14 @@ class StatisticsService:
         for reps, weight, _rpe, _date, _ex_name, eq_name in rows:
             if not eq_name:
                 continue
+            if (
+                self.settings is not None
+                and self.settings.get_bool("hide_preconfigured_equipment", False)
+                and self.equipment is not None
+            ):
+                detail = self.equipment.fetch_detail(eq_name)
+                if detail is not None and detail[2] == 0:
+                    continue
             item = stats.setdefault(eq_name, {"volume": 0.0, "sets": 0})
             item["volume"] += int(reps) * float(weight)
             item["sets"] += 1
@@ -395,6 +403,14 @@ class StatisticsService:
         for reps, weight, _rpe, _date, _ex_name, eq_name in rows:
             if not eq_name:
                 continue
+            if (
+                self.settings is not None
+                and self.settings.get_bool("hide_preconfigured_equipment", False)
+                and self.equipment is not None
+            ):
+                detail = self.equipment.fetch_detail(eq_name)
+                if detail is not None and detail[2] == 0:
+                    continue
             muscles = self.equipment.fetch_muscles(eq_name)
             for m in muscles:
                 item = stats.setdefault(m, {"volume": 0.0, "sets": 0})

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -82,7 +82,7 @@ class GymApp:
         self.template_workouts = TemplateWorkoutRepository(db_path)
         self.template_exercises = TemplateExerciseRepository(db_path)
         self.template_sets = TemplateSetRepository(db_path)
-        self.equipment = EquipmentRepository(db_path)
+        self.equipment = EquipmentRepository(db_path, self.settings_repo)
         self.exercise_catalog = ExerciseCatalogRepository(db_path)
         self.muscles_repo = MuscleRepository(db_path)
         self.exercise_names_repo = ExerciseNameRepository(db_path)
@@ -3655,6 +3655,13 @@ class GymApp:
 
         with eq_tab:
             st.header("Equipment Management")
+            hide_pre = st.checkbox(
+                "Hide Preconfigured Equipment",
+                value=self.settings_repo.get_bool(
+                    "hide_preconfigured_equipment", False
+                ),
+            )
+            self.settings_repo.set_bool("hide_preconfigured_equipment", hide_pre)
             with st.expander("Add Equipment"):
                 muscles_list = self.muscles_repo.fetch_all()
                 new_name = st.text_input("Equipment Name", key="equip_new_name")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -235,6 +235,26 @@ class APITestCase(unittest.TestCase):
         conn.close()
         self.assertEqual(count, 0)
 
+    def test_hide_preconfigured_equipment(self) -> None:
+        resp = self.client.get("/equipment")
+        self.assertIn("Olympic Barbell", resp.json())
+
+        resp = self.client.post(
+            "/settings/general", params={"hide_preconfigured_equipment": True}
+        )
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.get("/equipment/types")
+        self.assertNotIn("Free Weights", resp.json())
+        resp = self.client.get("/equipment")
+        self.assertNotIn("Olympic Barbell", resp.json())
+
+        resp = self.client.post(
+            "/settings/general", params={"hide_preconfigured_equipment": False}
+        )
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.get("/equipment")
+        self.assertIn("Olympic Barbell", resp.json())
+
     def test_plan_workflow(self) -> None:
         plan_date = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
 


### PR DESCRIPTION
## Summary
- add `hide_preconfigured_equipment` setting to `SettingsRepository`
- filter equipment lists in `EquipmentRepository` when preconfigured equipment is hidden
- propagate setting to Streamlit GUI and REST API
- skip hidden equipment in statistics calculations
- test hiding and unhiding equipment via API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880802f3dac83278c2f6233dda468fe