### PR TITLE
Add hiding of preconfigured exercises

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -61,7 +61,7 @@ class GymAPI:
         self.template_sets = TemplateSetRepository(db_path)
         self.settings = SettingsRepository(db_path, yaml_path)
         self.equipment = EquipmentRepository(db_path, self.settings)
-        self.exercise_catalog = ExerciseCatalogRepository(db_path)
+        self.exercise_catalog = ExerciseCatalogRepository(db_path, self.settings)
         self.muscles = MuscleRepository(db_path)
         self.exercise_names = ExerciseNameRepository(db_path)
         self.favorites = FavoriteExerciseRepository(db_path)
@@ -1683,6 +1683,7 @@ class GymAPI:
             ml_injury_training_enabled: bool = None,
             ml_injury_prediction_enabled: bool = None,
             hide_preconfigured_equipment: bool = None,
+            hide_preconfigured_exercises: bool = None,
         ):
             if body_weight is not None:
                 self.settings.set_float("body_weight", body_weight)
@@ -1749,6 +1750,10 @@ class GymAPI:
             if hide_preconfigured_equipment is not None:
                 self.settings.set_bool(
                     "hide_preconfigured_equipment", hide_preconfigured_equipment
+                )
+            if hide_preconfigured_exercises is not None:
+                self.settings.set_bool(
+                    "hide_preconfigured_exercises", hide_preconfigured_exercises
                 )
             return {"status": "updated"}
 

--- a/stats_service.py
+++ b/stats_service.py
@@ -62,9 +62,33 @@ class StatisticsService:
             return self.settings.get_float("body_weight", 80.0)
         return 80.0
 
+    def _all_names(self) -> List[str]:
+        names = self.exercise_names.fetch_all()
+        if (
+            self.settings is not None
+            and self.settings.get_bool("hide_preconfigured_exercises", False)
+            and self.catalog is not None
+        ):
+            filtered: list[str] = []
+            for n in names:
+                detail = self.catalog.fetch_detail(n)
+                if detail is not None and detail[-1] == 0:
+                    continue
+                filtered.append(n)
+            return filtered
+        return names
+
     def _alias_names(self, exercise: Optional[str]) -> List[str]:
         if not exercise:
-            return self.exercise_names.fetch_all()
+            return self._all_names()
+        if (
+            self.settings is not None
+            and self.settings.get_bool("hide_preconfigured_exercises", False)
+            and self.catalog is not None
+        ):
+            detail = self.catalog.fetch_detail(exercise)
+            if detail is not None and detail[-1] == 0:
+                return []
         return self.exercise_names.aliases(exercise)
 
     def exercise_history(
@@ -165,7 +189,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return total volume and set count per day."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -350,7 +374,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return volume and set count per equipment."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -392,7 +416,7 @@ class StatisticsService:
         """Return volume and set count per muscle based on equipment."""
         if self.equipment is None:
             return []
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -436,7 +460,7 @@ class StatisticsService:
         """Return volume and set count per muscle group."""
         if self.catalog is None:
             return []
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -587,7 +611,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> Dict[str, float]:
         """Return aggregated workout statistics."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -706,7 +730,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return daily training stress and cumulative fatigue values."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -779,7 +803,7 @@ class StatisticsService:
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> Dict[str, object]:
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -822,7 +846,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> Dict[str, float]:
         """Return training monotony value across the specified dates."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -877,7 +901,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return Training Stress Balance across dates."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -926,7 +950,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return efficiency score per workout."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -967,7 +991,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return volume per minute for each workout."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -999,7 +1023,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return sets per minute for each workout."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -1032,7 +1056,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return average rest duration between sets per workout."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -1066,7 +1090,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return total duration between first set start and last set finish."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -1107,7 +1131,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return total time under tension per workout."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -1143,7 +1167,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return exercise diversity score per workout."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -1178,7 +1202,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float | int]]:
         """Return workout counts and volume grouped by location."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -1212,7 +1236,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> Dict[str, float]:
         """Return overall stress and fatigue for the period."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -1265,7 +1289,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Forecast daily training volume for upcoming days."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,
@@ -1354,7 +1378,7 @@ class StatisticsService:
         end_date: Optional[str] = None,
     ) -> List[Dict[str, float]]:
         """Return daily readiness scores."""
-        names = self.exercise_names.fetch_all()
+        names = self._all_names()
         rows = self.sets.fetch_history_by_names(
             names,
             start_date=start_date,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -83,7 +83,7 @@ class GymApp:
         self.template_exercises = TemplateExerciseRepository(db_path)
         self.template_sets = TemplateSetRepository(db_path)
         self.equipment = EquipmentRepository(db_path, self.settings_repo)
-        self.exercise_catalog = ExerciseCatalogRepository(db_path)
+        self.exercise_catalog = ExerciseCatalogRepository(db_path, self.settings_repo)
         self.muscles_repo = MuscleRepository(db_path)
         self.exercise_names_repo = ExerciseNameRepository(db_path)
         self.favorites_repo = FavoriteExerciseRepository(db_path)
@@ -2317,6 +2317,13 @@ class GymApp:
     def _exercise_catalog_library(self) -> None:
         groups = self.exercise_catalog.fetch_muscle_groups()
         muscles = self.muscles_repo.fetch_all()
+        hide_pre = st.checkbox(
+            "Hide Preconfigured Exercises",
+            value=self.settings_repo.get_bool(
+                "hide_preconfigured_exercises", False
+            ),
+        )
+        self.settings_repo.set_bool("hide_preconfigured_exercises", hide_pre)
         favs = self.favorites_repo.fetch_all()
         with st.expander("Favorite Exercises", expanded=True):
             if favs:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -255,6 +255,33 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get("/equipment")
         self.assertIn("Olympic Barbell", resp.json())
 
+    def test_hide_preconfigured_exercises(self) -> None:
+        resp = self.client.get(
+            "/exercise_catalog",
+            params={"muscle_groups": "Chest"},
+        )
+        self.assertIn("Barbell Bench Press", resp.json())
+
+        resp = self.client.post(
+            "/settings/general", params={"hide_preconfigured_exercises": True}
+        )
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.get(
+            "/exercise_catalog",
+            params={"muscle_groups": "Chest"},
+        )
+        self.assertNotIn("Barbell Bench Press", resp.json())
+
+        resp = self.client.post(
+            "/settings/general", params={"hide_preconfigured_exercises": False}
+        )
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.get(
+            "/exercise_catalog",
+            params={"muscle_groups": "Chest"},
+        )
+        self.assertIn("Barbell Bench Press", resp.json())
+
     def test_plan_workflow(self) -> None:
         plan_date = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
 


### PR DESCRIPTION
## Summary
- allow ExerciseCatalogRepository to access settings
- add boolean setting `hide_preconfigured_exercises`
- filter exercise catalog functions and statistics when hiding exercises
- expose setting via REST and Streamlit
- test hiding preconfigured exercises

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68808839209c8327b466e959bdf524e6