### PR TITLE
Enable adding new muscles

### DIFF
--- a/db.py
+++ b/db.py
@@ -1188,6 +1188,21 @@ class MuscleRepository(BaseRepository):
                 (new_name, canonical),
             )
 
+    def add(self, name: str) -> None:
+        rows = super().fetch_all(
+            "SELECT canonical_name FROM muscles WHERE name = ?;",
+            (name,),
+        )
+        if rows:
+            if rows[0][0] == name:
+                raise ValueError("muscle exists")
+            raise ValueError("name is alias")
+        with self._connection() as conn:
+            conn.execute(
+                "INSERT INTO muscles (name, canonical_name) VALUES (?, ?);",
+                (name, name),
+            )
+
 
 class ExerciseNameRepository(BaseRepository):
     """Repository for exercise alias management."""

--- a/rest_api.py
+++ b/rest_api.py
@@ -169,6 +169,14 @@ class GymAPI:
         def list_muscles():
             return self.muscles.fetch_all()
 
+        @self.app.post("/muscles")
+        def add_muscle(name: str):
+            try:
+                self.muscles.add(name)
+                return {"status": "added"}
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
         @self.app.post("/muscles/link")
         def link_muscles(name1: str, name2: str):
             self.muscles.link(name1, name2)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3756,6 +3756,18 @@ class GymApp:
                     else:
                         st.warning("Name required")
 
+            with st.expander("Add Muscle"):
+                base_name = st.text_input("Muscle Name", key="base_muscle")
+                if st.button("Add Muscle"):
+                    if base_name:
+                        try:
+                            self.muscles_repo.add(base_name)
+                            st.success("Muscle added")
+                        except ValueError as e:
+                            st.warning(str(e))
+                    else:
+                        st.warning("Name required")
+
         with ex_tab:
             st.header("Exercise Aliases")
             names = self.exercise_names_repo.fetch_all()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -670,6 +670,17 @@ class APITestCase(unittest.TestCase):
         resp = self.client.delete("/exercise_catalog/Barbell Bench Press")
         self.assertEqual(resp.status_code, 400)
 
+    def test_add_muscle(self) -> None:
+        resp = self.client.post("/muscles", params={"name": "Obliques"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "added"})
+
+        resp = self.client.get("/muscles")
+        self.assertIn("Obliques", resp.json())
+
+        resp_dup = self.client.post("/muscles", params={"name": "Obliques"})
+        self.assertEqual(resp_dup.status_code, 400)
+
     def test_muscle_alias(self) -> None:
         resp = self.client.get("/muscles")
         self.assertEqual(resp.status_code, 200)

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -204,6 +204,19 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertEqual(cur.fetchone()[0], "Latissimus Dorsi")
         conn.close()
 
+    def test_add_muscle(self) -> None:
+        self.at.query_params["tab"] = "settings"
+        self.at.run()
+        mus_tab = self.at.tabs[10]
+        mus_tab.text_input[1].input("Obliques").run()
+        mus_tab.button[2].click().run()
+        self.at.run()
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT name FROM muscles WHERE name = ?;", ("Obliques",))
+        self.assertEqual(cur.fetchone()[0], "Obliques")
+        conn.close()
+
     def test_equipment_add_update_delete(self) -> None:
         self.at.query_params["tab"] = "settings"
         self.at.run()


### PR DESCRIPTION
## Summary
- extend MuscleRepository with an `add` method for creating new canonical muscle entries
- expose new `/muscles` POST endpoint in REST API
- add GUI form in settings tab to add muscles
- test new functionality via API and Streamlit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a1ae33808327bd4b40ed0ae37d81