### PR TITLE
Add equipment type management

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -11,6 +11,7 @@ from db import (
     TemplateExerciseRepository,
     TemplateSetRepository,
     EquipmentRepository,
+    EquipmentTypeRepository,
     ExerciseCatalogRepository,
     MuscleRepository,
     ExerciseNameRepository,
@@ -60,7 +61,8 @@ class GymAPI:
         self.template_exercises = TemplateExerciseRepository(db_path)
         self.template_sets = TemplateSetRepository(db_path)
         self.settings = SettingsRepository(db_path, yaml_path)
-        self.equipment = EquipmentRepository(db_path, self.settings)
+        self.equipment_types = EquipmentTypeRepository(db_path, self.settings)
+        self.equipment = EquipmentRepository(db_path, self.settings, self.equipment_types)
         self.exercise_catalog = ExerciseCatalogRepository(db_path, self.settings)
         self.muscles = MuscleRepository(db_path)
         self.exercise_names = ExerciseNameRepository(db_path)
@@ -138,6 +140,14 @@ class GymAPI:
         @self.app.get("/equipment/types")
         def list_equipment_types():
             return self.equipment.fetch_types()
+
+        @self.app.post("/equipment/types")
+        def add_equipment_type(name: str):
+            try:
+                tid = self.equipment_types.add(name)
+                return {"id": tid}
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
 
         @self.app.get("/equipment")
         def list_equipment(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3669,6 +3669,17 @@ class GymApp:
                 ),
             )
             self.settings_repo.set_bool("hide_preconfigured_equipment", hide_pre)
+            with st.expander("Add Equipment Type"):
+                new_type = st.text_input("Type Name", key="new_eq_type")
+                if st.button("Add Type"):
+                    if new_type:
+                        try:
+                            self.equipment.types.add(new_type)
+                            st.success("Type added")
+                        except ValueError as e:
+                            st.warning(str(e))
+                    else:
+                        st.warning("Name required")
             with st.expander("Add Equipment"):
                 muscles_list = self.muscles_repo.fetch_all()
                 new_name = st.text_input("Equipment Name", key="equip_new_name")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -449,6 +449,11 @@ class APITestCase(unittest.TestCase):
         types = response.json()
         self.assertIn("Free Weights", types)
 
+        add_type = self.client.post("/equipment/types", params={"name": "MyType"})
+        self.assertEqual(add_type.status_code, 200)
+        self.assertIsInstance(add_type.json()["id"], int)
+        self.assertIn("MyType", self.client.get("/equipment/types").json())
+
         response = self.client.get(
             "/equipment", params={"equipment_type": "Free Weights", "prefix": "Olympic"}
         )
@@ -483,7 +488,7 @@ class APITestCase(unittest.TestCase):
         resp = self.client.post(
             "/equipment",
             params={
-                "equipment_type": "Custom",
+                "equipment_type": "MyType",
                 "name": "My Eq",
                 "muscles": "Foo|Bar",
             },
@@ -495,7 +500,7 @@ class APITestCase(unittest.TestCase):
         resp = self.client.put(
             "/equipment/My Eq",
             params={
-                "equipment_type": "Custom",
+                "equipment_type": "MyType",
                 "muscles": "Foo|Baz",
                 "new_name": "My Eq2",
             },

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -221,10 +221,14 @@ class StreamlitAppTest(unittest.TestCase):
         self.at.query_params["tab"] = "settings"
         self.at.run()
         eq_tab = self.at.tabs[9]
-        eq_tab.selectbox[0].select("Free Weights").run()
-        eq_tab.text_input[0].input("TestEq").run()
-        eq_tab.multiselect[0].select("Biceps Brachii").run()
+        eq_tab.text_input[0].input("MyType").run()
         eq_tab.button[0].click().run()
+        self.at.run()
+        eq_tab = self.at.tabs[9]
+        eq_tab.selectbox[0].select("MyType").run()
+        eq_tab.text_input[1].input("TestEq").run()
+        eq_tab.multiselect[0].select("Biceps Brachii").run()
+        eq_tab.button[1].click().run()
         self.at.run()
         eq_tab = self.at.tabs[9]
         target = None
@@ -234,7 +238,7 @@ class StreamlitAppTest(unittest.TestCase):
                 break
         self.assertIsNotNone(target)
         target.text_input[0].input("TestEq2").run()
-        target.text_input[1].input("Free Weights").run()
+        target.text_input[1].input("MyType").run()
         target.multiselect[0].select("Brachialis").run()
         target.button[0].click().run()
         self.at.run()


### PR DESCRIPTION
## Summary
- introduce `equipment_types` table
- add `EquipmentTypeRepository`
- store default types on data import
- require valid equipment type when adding/updating equipment
- expose `/equipment/types` POST endpoint
- allow adding new types in settings tab
- test equipment type creation via API and GUI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a666c7dc8327baa6649f22bb31db