### PR TITLE
Add muscle group management

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -20,6 +20,7 @@ from db import (
     EquipmentRepository,
     ExerciseCatalogRepository,
     MuscleRepository,
+    MuscleGroupRepository,
     ExerciseNameRepository,
     SettingsRepository,
     PyramidTestRepository,
@@ -85,6 +86,7 @@ class GymApp:
         self.equipment = EquipmentRepository(db_path, self.settings_repo)
         self.exercise_catalog = ExerciseCatalogRepository(db_path, self.settings_repo)
         self.muscles_repo = MuscleRepository(db_path)
+        self.muscle_groups_repo = MuscleGroupRepository(db_path, self.muscles_repo)
         self.exercise_names_repo = ExerciseNameRepository(db_path)
         self.favorites_repo = FavoriteExerciseRepository(db_path)
         self.favorite_templates_repo = FavoriteTemplateRepository(db_path)
@@ -3778,6 +3780,40 @@ class GymApp:
                             st.warning(str(e))
                     else:
                         st.warning("Name required")
+
+            with st.expander("Muscle Groups", expanded=True):
+                groups = self.muscle_groups_repo.fetch_all()
+                new_group = st.text_input("New Group", key="new_group")
+                if st.button("Add Group"):
+                    if new_group:
+                        try:
+                            self.muscle_groups_repo.add(new_group)
+                            st.success("Group added")
+                        except ValueError as e:
+                            st.warning(str(e))
+                    else:
+                        st.warning("Name required")
+                for g in groups:
+                    gexp = st.expander(g)
+                    with gexp:
+                        new_name = st.text_input("Name", g, key=f"grp_name_{g}")
+                        sel = st.multiselect(
+                            "Muscles", muscles, self.muscle_groups_repo.fetch_muscles(g),
+                            key=f"grp_mus_{g}"
+                        )
+                        if st.button("Update", key=f"grp_up_{g}"):
+                            try:
+                                self.muscle_groups_repo.rename(g, new_name)
+                                self.muscle_groups_repo.set_members(new_name, sel)
+                                st.success("Updated")
+                            except ValueError as e:
+                                st.warning(str(e))
+                        if st.button("Delete", key=f"grp_del_{g}"):
+                            try:
+                                self.muscle_groups_repo.delete(g)
+                                st.success("Deleted")
+                            except ValueError as e:
+                                st.warning(str(e))
 
         with ex_tab:
             st.header("Exercise Aliases")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2298,6 +2298,34 @@ class APITestCase(unittest.TestCase):
         self.client.delete(f"/tags/{tid}")
         self.assertEqual(self.client.get("/tags").json(), [])
 
+    def test_muscle_group_management(self) -> None:
+        resp = self.client.post("/muscle_groups", params={"name": "Arms"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "added"})
+
+        groups = self.client.get("/muscle_groups").json()
+        self.assertIn("Arms", groups)
+
+        assign = self.client.post(
+            "/muscle_groups/Arms/muscles", params={"muscle": "Biceps Brachii"}
+        )
+        self.assertEqual(assign.status_code, 200)
+        self.assertEqual(assign.json(), {"status": "assigned"})
+
+        mus = self.client.get("/muscle_groups/Arms/muscles").json()
+        self.assertEqual(mus, ["Biceps Brachii"])
+
+        upd = self.client.put("/muscle_groups/Arms", params={"new_name": "Upper Arms"})
+        self.assertEqual(upd.status_code, 200)
+
+        groups = self.client.get("/muscle_groups").json()
+        self.assertIn("Upper Arms", groups)
+
+        delete = self.client.delete("/muscle_groups/Upper Arms")
+        self.assertEqual(delete.status_code, 200)
+        self.assertEqual(delete.json(), {"status": "deleted"})
+        self.assertNotIn("Upper Arms", self.client.get("/muscle_groups").json())
+
     def test_template_workflow(self) -> None:
         resp = self.client.post(
             "/templates",

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -217,6 +217,34 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertEqual(cur.fetchone()[0], "Obliques")
         conn.close()
 
+    def test_muscle_group_management(self) -> None:
+        self.at.query_params["tab"] = "settings"
+        self.at.run()
+        mus_tab = self.at.tabs[10]
+        group_exp = mus_tab.expander[3]
+        group_exp.text_input[0].input("Arms").run()
+        group_exp.button[0].click().run()
+        self.at.run()
+        mus_tab = self.at.tabs[10]
+        group_exp = mus_tab.expander[3]
+        target = None
+        for exp in group_exp.expander:
+            if exp.label == "Arms":
+                target = exp
+                break
+        self.assertIsNotNone(target)
+        target.multiselect[0].select("Biceps Brachii").run()
+        target.button[0].click().run()
+        self.at.run()
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT group_name FROM muscle_group_members WHERE muscle_name = ?;",
+            ("Biceps Brachii",),
+        )
+        self.assertEqual(cur.fetchone()[0], "Arms")
+        conn.close()
+
     def test_equipment_add_update_delete(self) -> None:
         self.at.query_params["tab"] = "settings"
         self.at.run()


### PR DESCRIPTION
## Summary
- create tables for muscle groups and members
- add MuscleGroupRepository for editing groups and members
- expose muscle group CRUD endpoints in REST API
- integrate muscle group management into settings UI
- test muscle group operations via API and Streamlit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880abc76b048327859e86c18ecfe4e7