### PR TITLE
Implement AI-generated workout plans

### DIFF
--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -93,8 +93,8 @@ class StreamlitAppTest(unittest.TestCase):
     def test_add_favorite_exercise(self) -> None:
         self.at.query_params["tab"] = "library"
         self.at.run()
-        self.at.selectbox[6].select("Barbell Bench Press").run()
-        self.at.button[5].click().run()
+        self.at.selectbox[14].select("Barbell Bench Press").run()
+        self.at.button[13].click().run()
 
         conn = self._connect()
         cur = conn.cursor()


### PR DESCRIPTION
## Summary
- add AI plan generation endpoint and GUI controls
- let PlannerService create plans via recommendation engine
- expose `/planned_workouts/auto_plan` API route
- update recommendation service to share prescription logic
- expand tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b3be6ca08327991b33c8f9cc5a06