### PR TITLE
Fix equipment type visibility

### DIFF
--- a/db.py
+++ b/db.py
@@ -1547,10 +1547,11 @@ class EquipmentTypeRepository(BaseRepository):
         return self.settings.get_bool("hide_preconfigured_equipment", False)
 
     def fetch_all(self) -> List[str]:
-        query = "SELECT name FROM equipment_types WHERE 1=1"
-        if self._hide_preconfigured():
-            query += " AND is_custom = 1"
-        query += " ORDER BY name;"
+        # Equipment types should always be available regardless of the
+        # ``hide_preconfigured_equipment`` setting. Filtering by ``is_custom``
+        # would prevent selecting predefined types when adding new equipment.
+        # Therefore we no longer apply the hide-preconfigured flag here.
+        query = "SELECT name FROM equipment_types ORDER BY name;"
         rows = super().fetch_all(query)
         return [r[0] for r in rows]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -244,7 +244,9 @@ class APITestCase(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         resp = self.client.get("/equipment/types")
-        self.assertNotIn("Free Weights", resp.json())
+        # Equipment types must remain visible even when preconfigured equipment
+        # is hidden. The toggle should only affect individual equipment items.
+        self.assertIn("Free Weights", resp.json())
         resp = self.client.get("/equipment")
         self.assertNotIn("Olympic Barbell", resp.json())
 


### PR DESCRIPTION
## Summary
- always return all equipment types regardless of hide setting
- keep equipment types visible in API test
- handle dynamic widget indexes in GUI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880cd81a7148327b22ad985157b812a