### PR TITLE
Ensure dropdowns sorted

### DIFF
--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -237,6 +237,18 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertEqual(cur.fetchone()[0], "Obliques")
         conn.close()
 
+    def test_muscle_dropdown_sorted(self) -> None:
+        self.at.query_params["tab"] = "settings"
+        self.at.run()
+        mus_tab = self.at.tabs[10]
+        mus_tab.text_input[1].input("Aardvark").run()
+        mus_tab.button[2].click().run()
+        self.at.run()
+        mus_tab = self.at.tabs[10]
+        idx = _find_by_label(mus_tab.selectbox, "Muscle 1")
+        options = mus_tab.selectbox[idx].options
+        self.assertEqual(options, sorted(options))
+
     def test_muscle_group_management(self) -> None:
         self.at.query_params["tab"] = "settings"
         self.at.run()


### PR DESCRIPTION
## Summary
- sort all dropdown lists alphabetically
- default training type selections to `strength`
- keep theme options sorted
- ensure lists from DB are ordered before showing
- test muscle dropdown remains sorted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d79127308327948585e38870b59d