### PR TITLE
Add muscles like equipment toggle

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2501,23 +2501,48 @@ class GymApp:
                 group = st.selectbox("Muscle Group", groups, key="cust_ex_group")
                 name = st.text_input("Exercise Name", key="cust_ex_name")
                 variants = st.text_input("Variants", key="cust_ex_variants")
-                eq_sel = st.multiselect("Equipment", equipment_names, key="cust_ex_eq")
-                primary = st.selectbox("Primary Muscle", muscles, key="cust_ex_primary")
-                secondary = st.multiselect("Secondary", muscles, key="cust_ex_sec")
-                tertiary = st.multiselect("Tertiary", muscles, key="cust_ex_ter")
-                other = st.multiselect("Other", muscles, key="cust_ex_other")
+                eq_sel = st.multiselect(
+                    "Equipment", equipment_names, key="cust_ex_eq"
+                )
+                match_muscles = st.checkbox(
+                    "Muscles Like Equipment", key="cust_ex_match"
+                )
+                primary_sel = st.selectbox(
+                    "Primary Muscle", muscles, key="cust_ex_primary"
+                )
+                secondary_sel = st.multiselect(
+                    "Secondary", muscles, key="cust_ex_sec"
+                )
+                tertiary_sel = st.multiselect(
+                    "Tertiary", muscles, key="cust_ex_ter"
+                )
+                other_sel = st.multiselect("Other", muscles, key="cust_ex_other")
                 if st.button("Add Exercise", key="cust_ex_add"):
                     if name:
                         try:
+                            if match_muscles and eq_sel:
+                                muscs: list[str] = []
+                                for eq in eq_sel:
+                                    muscs.extend(self.equipment.fetch_muscles(eq))
+                                uniq = list(dict.fromkeys(muscs))
+                                primary = uniq[0]
+                                secondary = "|".join(uniq[1:])
+                                tertiary = ""
+                                other = ""
+                            else:
+                                primary = primary_sel
+                                secondary = "|".join(secondary_sel)
+                                tertiary = "|".join(tertiary_sel)
+                                other = "|".join(other_sel)
                             self.exercise_catalog.add(
                                 group,
                                 name,
                                 variants,
                                 "|".join(eq_sel),
                                 primary,
-                                "|".join(secondary),
-                                "|".join(tertiary),
-                                "|".join(other),
+                                secondary,
+                                tertiary,
+                                other,
                             )
                             st.success("Exercise added")
                         except ValueError as e:
@@ -2591,23 +2616,48 @@ class GymApp:
                 group = st.selectbox("Muscle Group", groups, key="cust_ex_group")
                 name = st.text_input("Exercise Name", key="cust_ex_name")
                 variants = st.text_input("Variants", key="cust_ex_variants")
-                eq_sel = st.multiselect("Equipment", equipment_names, key="cust_ex_eq")
-                primary = st.selectbox("Primary Muscle", muscles, key="cust_ex_primary")
-                secondary = st.multiselect("Secondary", muscles, key="cust_ex_sec")
-                tertiary = st.multiselect("Tertiary", muscles, key="cust_ex_ter")
-                other = st.multiselect("Other", muscles, key="cust_ex_other")
+                eq_sel = st.multiselect(
+                    "Equipment", equipment_names, key="cust_ex_eq"
+                )
+                match_muscles = st.checkbox(
+                    "Muscles Like Equipment", key="cust_ex_match"
+                )
+                primary_sel = st.selectbox(
+                    "Primary Muscle", muscles, key="cust_ex_primary"
+                )
+                secondary_sel = st.multiselect(
+                    "Secondary", muscles, key="cust_ex_sec"
+                )
+                tertiary_sel = st.multiselect(
+                    "Tertiary", muscles, key="cust_ex_ter"
+                )
+                other_sel = st.multiselect("Other", muscles, key="cust_ex_other")
                 if st.button("Add Exercise", key="cust_ex_add"):
                     if name:
                         try:
+                            if match_muscles and eq_sel:
+                                muscs: list[str] = []
+                                for eq in eq_sel:
+                                    muscs.extend(self.equipment.fetch_muscles(eq))
+                                uniq = list(dict.fromkeys(muscs))
+                                primary = uniq[0]
+                                secondary = "|".join(uniq[1:])
+                                tertiary = ""
+                                other = ""
+                            else:
+                                primary = primary_sel
+                                secondary = "|".join(secondary_sel)
+                                tertiary = "|".join(tertiary_sel)
+                                other = "|".join(other_sel)
                             self.exercise_catalog.add(
                                 group,
                                 name,
                                 variants,
                                 "|".join(eq_sel),
                                 primary,
-                                "|".join(secondary),
-                                "|".join(tertiary),
-                                "|".join(other),
+                                secondary,
+                                tertiary,
+                                other,
                             )
                             st.success("Exercise added")
                         except ValueError as e:

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -145,22 +145,29 @@ class StreamlitAppTest(unittest.TestCase):
         self.at.run()
         # Custom exercise
         cust_tab = self.at.tabs[12]
-        cust_tab.selectbox[0].select("Back").run()
+        idx_group = _find_by_label(cust_tab.selectbox, "Muscle Group", key="cust_ex_group")
+        cust_tab.selectbox[idx_group].select("Chest").run()
         cust_tab.text_input[0].input("CustomEx").run()
         cust_tab.text_input[1].input("Var1").run()
-        cust_tab.multiselect[0].select("Cable Crossover Machine").run()
-        cust_tab.selectbox[1].select("Latissimus Dorsi").run()
-        cust_tab.button[0].click().run()
+        idx_eq = _find_by_label(cust_tab.multiselect, "Equipment", key="cust_ex_eq")
+        cust_tab.multiselect[idx_eq].select("Chest Press Machine").run()
+        idx_chk = _find_by_label(cust_tab.checkbox, "Muscles Like Equipment", key="cust_ex_match")
+        cust_tab.checkbox[idx_chk].check().run()
+        idx_btn = _find_by_label(cust_tab.button, "Add Exercise", key="cust_ex_add")
+        cust_tab.button[idx_btn].click().run()
         self.at.run()
         cust_tab = self.at.tabs[12]
 
         conn = self._connect()
         cur = conn.cursor()
         cur.execute(
-            "SELECT muscle_group, name FROM exercise_catalog WHERE name = ?;",
+            "SELECT muscle_group, primary_muscle, secondary_muscle FROM exercise_catalog WHERE name = ?;",
             ("CustomEx",),
         )
-        self.assertEqual(cur.fetchone(), ("Back", "CustomEx"))
+        self.assertEqual(
+            cur.fetchone(),
+            ("Chest", "Pectoralis Major", "Anterior Deltoid|Triceps Brachii"),
+        )
 
         # Body weight log
         bw_tab = self.at.tabs[13]


### PR DESCRIPTION
## Summary
- allow auto-populating muscle fields from selected equipment when adding custom exercises
- test that muscle linking toggle populates muscles correctly

## Testing
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_custom_exercise_and_logs -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e1ba19b083279f1c770bed52d057