### PR TITLE
Ensure wellness info flows to AI planner

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -107,6 +107,7 @@ class GymAPI:
             self.goal_model,
             self.body_weights,
             self.goals,
+            self.wellness,
         )
         self.planner = PlannerService(
             self.workouts,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -131,6 +131,7 @@ class GymApp:
             self.goal_model,
             self.body_weights_repo,
             self.goals_repo,
+            self.wellness_repo,
         )
         self.planner = PlannerService(
             self.workouts,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2626,6 +2626,16 @@ class APITestCase(unittest.TestCase):
                 f"/exercises/{ex_id}/sets",
                 params={"reps": 5, "weight": w, "rpe": 8},
             )
+        self.client.post(
+            "/wellness",
+            params={
+                "date": datetime.date.today().isoformat(),
+                "calories": 2500.0,
+                "sleep_hours": 8.0,
+                "sleep_quality": 5.0,
+                "stress_level": 3,
+            },
+        )
         plan_date = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
         resp = self.client.post(
             "/planned_workouts/auto_plan",
@@ -2645,6 +2655,10 @@ class APITestCase(unittest.TestCase):
             [5] * len(weights),
             list(range(len(weights))),
             [8] * len(weights),
+            calories=[2500.0],
+            sleep_hours=[8.0],
+            sleep_quality=[5.0],
+            stress_levels=[3],
             body_weight=80.0,
             months_active=1.0,
             workouts_per_month=len(weights),


### PR DESCRIPTION
## Summary
- extend `RecommendationService` with wellness repository
- feed recent wellness logs into exercise prescription
- pass wellness repo from REST API and Streamlit app
- test that AI planner accounts for wellness data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881fdd9fbc4832795f3f67db2eee1e3