### PR TITLE
Add Autoplanner status tracking

### DIFF
--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -524,6 +524,7 @@ class StreamlitFullGUITest(unittest.TestCase):
             "Body Weight Logs",
             "Wellness Logs",
             "Workout Tags",
+            "Autoplanner Status",
         ]:
             self.assertIn(name, labels)
 


### PR DESCRIPTION
## Summary
- track autoplanner runs and ML model status in database
- log autoplanner success/errors in PlannerService
- expose new `/autoplanner/status` endpoint
- show Autoplanner Status tab in Settings
- record model load/train/predict times
- test autoplanner status via REST API
- log exercise prescription runs and show their status

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882109581008327a10f3beba14af35b