### PR TITLE
Add heart rate logging endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+1. Add HeartRateRepository class with logging, fetching, updating, and deleting capabilities in db.py [complete]
+2. Instantiate HeartRateRepository in rest_api.GymAPI and expose REST endpoints for logging and retrieving heart rate data [complete]
+3. Add tests in tests/test_api.py verifying heart rate logging and retrieval [complete]
+4. Implement StatisticsService.heart_rate_summary and corresponding API endpoint
+5. Display heart rate logs and summary in the Streamlit GUI
+6. Extend long term usage test to include heart rate logging
+7. Add GUI tests for heart rate functionality

--- a/stats_service.py
+++ b/stats_service.py
@@ -8,6 +8,7 @@ from db import (
     BodyWeightRepository,
     EquipmentRepository,
     WellnessRepository,
+    HeartRateRepository,
 )
 from ml_service import (
     VolumeModelService,
@@ -37,6 +38,7 @@ class StatisticsService:
         wellness_repo: "WellnessRepository" | None = None,
         catalog_repo: "ExerciseCatalogRepository" | None = None,
         workout_repo: "WorkoutRepository" | None = None,
+        heart_rate_repo: "HeartRateRepository" | None = None,
     ) -> None:
         self.sets = set_repo
         self.exercise_names = name_repo
@@ -51,6 +53,7 @@ class StatisticsService:
         self.wellness = wellness_repo
         self.catalog = catalog_repo
         self.workouts = workout_repo
+        self.heart_rates = heart_rate_repo
 
     def _current_body_weight(self) -> float:
         """Fetch the latest logged body weight or fallback to settings."""


### PR DESCRIPTION
## Summary
- track heart rate logs in database
- expose REST endpoints for heart rate logging and retrieval
- update statistics service to accept heart rate repository
- add API tests for heart rate logging
- create TODO list for remaining heart rate features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688220d2dbc48327a39b1ad748d3e95c