### PR TITLE
Add heart rate summary statistics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 1. Add HeartRateRepository class with logging, fetching, updating, and deleting capabilities in db.py [complete]
 2. Instantiate HeartRateRepository in rest_api.GymAPI and expose REST endpoints for logging and retrieving heart rate data [complete]
 3. Add tests in tests/test_api.py verifying heart rate logging and retrieval [complete]
-4. Implement StatisticsService.heart_rate_summary and corresponding API endpoint
+4. Implement StatisticsService.heart_rate_summary and corresponding API endpoint [complete]
 5. Display heart rate logs and summary in the Streamlit GUI
 6. Extend long term usage test to include heart rate logging
 7. Add GUI tests for heart rate functionality

--- a/rest_api.py
+++ b/rest_api.py
@@ -1810,6 +1810,10 @@ class GymAPI:
         def stats_rating_stats(start_date: str = None, end_date: str = None):
             return self.statistics.rating_stats(start_date, end_date)
 
+        @self.app.get("/stats/heart_rate_summary")
+        def stats_heart_rate_summary(start_date: str = None, end_date: str = None):
+            return self.statistics.heart_rate_summary(start_date, end_date)
+
         @self.app.get("/ml_logs/{model_name}")
         def get_ml_logs(model_name: str, start_date: str = None, end_date: str = None):
             rows = self.ml_logs.fetch_range(model_name, start_date, end_date)

--- a/stats_service.py
+++ b/stats_service.py
@@ -1630,6 +1630,37 @@ class StatisticsService:
             "avg_stress": round(sum(stress) / len(stress), 2) if stress else 0.0,
         }
 
+    def heart_rate_history(
+        self, start_date: str | None = None, end_date: str | None = None
+    ) -> list[dict[str, int | str]]:
+        """Return logged heart rate entries ordered by timestamp."""
+        if self.heart_rates is None:
+            return []
+        rows = self.heart_rates.fetch_range(start_date, end_date)
+        return [
+            {
+                "id": rid,
+                "workout_id": wid,
+                "timestamp": ts,
+                "heart_rate": hr,
+            }
+            for rid, wid, ts, hr in rows
+        ]
+
+    def heart_rate_summary(
+        self, start_date: str | None = None, end_date: str | None = None
+    ) -> dict[str, float]:
+        """Return average, min and max heart rate for the range."""
+        history = self.heart_rate_history(start_date, end_date)
+        if not history:
+            return {"avg": 0.0, "min": 0.0, "max": 0.0}
+        rates = [h["heart_rate"] for h in history]
+        return {
+            "avg": round(sum(rates) / len(rates), 2),
+            "min": float(min(rates)),
+            "max": float(max(rates)),
+        }
+
     def exercise_frequency(
         self,
         exercise: str | None = None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2265,6 +2265,27 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(del_resp.status_code, 200)
         self.assertEqual(self.client.get("/workouts/1/heart_rate").json(), [])
 
+    def test_heart_rate_summary(self) -> None:
+        self.client.post("/workouts", params={"date": "2023-01-01"})
+        self.client.post(
+            "/workouts/1/heart_rate",
+            params={"timestamp": "2023-01-01T10:00:00", "heart_rate": 120},
+        )
+        self.client.post(
+            "/workouts/1/heart_rate",
+            params={"timestamp": "2023-01-01T10:05:00", "heart_rate": 130},
+        )
+
+        resp = self.client.get(
+            "/stats/heart_rate_summary",
+            params={"start_date": "2023-01-01", "end_date": "2023-01-02"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertAlmostEqual(data["avg"], 125.0)
+        self.assertEqual(data["min"], 120.0)
+        self.assertEqual(data["max"], 130.0)
+
     def test_exercise_frequency(self) -> None:
         d1 = (datetime.date.today() - datetime.timedelta(days=7)).isoformat()
         d2 = datetime.date.today().isoformat()


### PR DESCRIPTION
## Summary
- add heart rate history and summary methods in `StatisticsService`
- expose `/stats/heart_rate_summary` endpoint in REST API
- test heart rate summary calculations
- mark TODO step as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882247b0b1c8327b6e5d941b2727f28