### PR TITLE
Add heart rate GUI support and tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,6 @@
 2. Instantiate HeartRateRepository in rest_api.GymAPI and expose REST endpoints for logging and retrieving heart rate data [complete]
 3. Add tests in tests/test_api.py verifying heart rate logging and retrieval [complete]
 4. Implement StatisticsService.heart_rate_summary and corresponding API endpoint [complete]
-5. Display heart rate logs and summary in the Streamlit GUI
-6. Extend long term usage test to include heart rate logging
-7. Add GUI tests for heart rate functionality
+5. Display heart rate logs and summary in the Streamlit GUI [complete]
+6. Extend long term usage test to include heart rate logging [complete]
+7. Add GUI tests for heart rate functionality [complete]


### PR DESCRIPTION
## Summary
- show heart rate logs and metrics in workouts
- add Heart Rate Logs tab to settings
- cover heart rate logging in GUI tests
- extend long term usage test for heart rate logging
- mark TODO items as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822849b734832781b3e3af0778329c