### PR TITLE
GUI layout overhaul

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,0 @@
-1. Add HeartRateRepository class with logging, fetching, updating, and deleting capabilities in db.py [complete]
-2. Instantiate HeartRateRepository in rest_api.GymAPI and expose REST endpoints for logging and retrieving heart rate data [complete]
-3. Add tests in tests/test_api.py verifying heart rate logging and retrieval [complete]
-4. Implement StatisticsService.heart_rate_summary and corresponding API endpoint [complete]
-5. Display heart rate logs and summary in the Streamlit GUI [complete]
-6. Extend long term usage test to include heart rate logging [complete]
-7. Add GUI tests for heart rate functionality [complete]

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -376,6 +376,13 @@ class StreamlitAppTest(unittest.TestCase):
             data = yaml.safe_load(f)
         self.assertEqual(data["theme"], "dark")
 
+    def test_toggle_theme_header_button(self) -> None:
+        idx = _find_by_label(self.at.button, "Toggle Theme", key="toggle_theme_header")
+        self.at.button[idx].click().run()
+        with open(self.yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        self.assertEqual(data["theme"], "dark")
+
     def test_git_pull_button(self) -> None:
         self.at.query_params["tab"] = "settings"
         self.at.run()


### PR DESCRIPTION
## Summary
- refactor layout with new `LayoutManager`
- move page container helpers to new class
- add theme toggle button in header
- adjust GUI tests for new header button
- remove completed TODO list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688231f4d98483278bfe677c04c2dfab