### PR TITLE
Add training type summary analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - View velocity history per exercise with `/stats/velocity_history` and charts in the Stats tab.
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.
 - Summarize workouts by location with `/stats/location_summary` and view tables in the Reports tab.
+- Summarize workouts by training type with `/stats/training_type_summary`.
 - Evaluate exercise frequency per week with `/stats/exercise_frequency`.
 - Evaluate workout schedule consistency with `/stats/workout_consistency` displayed in Reports.
 - Analyze week-over-week volume change with `/stats/weekly_volume_change` displayed in the Reports tab.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1336,6 +1336,13 @@ class GymAPI:
         ):
             return self.statistics.location_summary(start_date, end_date)
 
+        @self.app.get("/stats/training_type_summary")
+        def stats_training_type_summary(
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.training_type_summary(start_date, end_date)
+
         @self.app.get("/stats/workout_consistency")
         def stats_workout_consistency(
             start_date: str = None,

--- a/stats_service.py
+++ b/stats_service.py
@@ -1233,6 +1233,35 @@ class StatisticsService:
             )
         return result
 
+    def training_type_summary(
+        self, start_date: Optional[str] = None, end_date: Optional[str] = None
+    ) -> List[Dict[str, float | int]]:
+        """Return workout counts and volume grouped by training type."""
+        if self.workouts is None:
+            return []
+        workouts = self.workouts.fetch_all_workouts(start_date, end_date)
+        stats: Dict[str, Dict[str, float | int]] = {}
+        for wid, _date, _s, _e, t_type, _notes, _rating in workouts:
+            summary = self.sets.workout_summary(wid)
+            entry = stats.setdefault(
+                t_type, {"workouts": 0, "volume": 0.0, "sets": 0}
+            )
+            entry["workouts"] += 1
+            entry["volume"] += summary["volume"]
+            entry["sets"] += summary["sets"]
+        result: List[Dict[str, float | int]] = []
+        for t_type in sorted(stats):
+            entry = stats[t_type]
+            result.append(
+                {
+                    "training_type": t_type,
+                    "workouts": entry["workouts"],
+                    "volume": round(float(entry["volume"]), 2),
+                    "sets": entry["sets"],
+                }
+            )
+        return result
+
     def stress_overview(
         self,
         start_date: Optional[str] = None,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3617,6 +3617,10 @@ class GymApp:
             loc_stats = self.stats.location_summary(start_str, end_str)
             if loc_stats:
                 st.table(loc_stats)
+        with st.expander("Training Type Summary", expanded=False):
+            tt_stats = self.stats.training_type_summary(start_str, end_str)
+            if tt_stats:
+                st.table(tt_stats)
         with st.expander("Workout Consistency", expanded=False):
             consistency = self.stats.workout_consistency(start_str, end_str)
             metrics = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1654,6 +1654,44 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(data[1]["workouts"], 1)
         self.assertAlmostEqual(data[1]["volume"], 500.0)
 
+    def test_training_type_summary_endpoint(self) -> None:
+        self.client.post(
+            "/workouts",
+            params={"date": "2023-01-01", "training_type": "strength"},
+        )
+        self.client.post(
+            "/workouts",
+            params={"date": "2023-01-02", "training_type": "hypertrophy"},
+        )
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/workouts/2/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 8},
+        )
+        self.client.post(
+            "/exercises/2/sets",
+            params={"reps": 5, "weight": 110.0, "rpe": 8},
+        )
+        resp = self.client.get("/stats/training_type_summary")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["training_type"], "hypertrophy")
+        self.assertEqual(data[0]["workouts"], 1)
+        self.assertAlmostEqual(data[0]["volume"], 550.0)
+        self.assertEqual(data[0]["sets"], 1)
+        self.assertEqual(data[1]["training_type"], "strength")
+        self.assertEqual(data[1]["workouts"], 1)
+        self.assertAlmostEqual(data[1]["volume"], 500.0)
+        self.assertEqual(data[1]["sets"], 1)
+
     def test_weekly_volume_change_endpoint(self) -> None:
         d1 = (datetime.date.today() - datetime.timedelta(days=14)).isoformat()
         d2 = (datetime.date.today() - datetime.timedelta(days=7)).isoformat()


### PR DESCRIPTION
## Summary
- compute statistics by training type
- expose `/stats/training_type_summary` endpoint
- display training type summary in Streamlit
- document the new endpoint in README
- test training type summary analytics

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68824f1b81b88327956fffde4cfa7812