### PR TITLE
Add heart rate zone analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Forecast future body weight trends with `/stats/weight_forecast`.
 - View weight history, BMI charts and forecasts in the Progress tab's new "Body Weight" section.
 - Review workout ratings via `/stats/rating_history` and `/stats/rating_stats`.
+- Analyze heart rate zone distribution with `/stats/heart_rate_zones`.
 
 ## Installation
 

--- a/rest_api.py
+++ b/rest_api.py
@@ -1842,6 +1842,10 @@ class GymAPI:
         def stats_heart_rate_summary(start_date: str = None, end_date: str = None):
             return self.statistics.heart_rate_summary(start_date, end_date)
 
+        @self.app.get("/stats/heart_rate_zones")
+        def stats_heart_rate_zones(start_date: str = None, end_date: str = None):
+            return self.statistics.heart_rate_zones(start_date, end_date)
+
         @self.app.get("/ml_logs/{model_name}")
         def get_ml_logs(model_name: str, start_date: str = None, end_date: str = None):
             rows = self.ml_logs.fetch_range(model_name, start_date, end_date)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2345,6 +2345,29 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(data["min"], 120.0)
         self.assertEqual(data["max"], 130.0)
 
+    def test_heart_rate_zones(self) -> None:
+        self.client.post("/workouts", params={"date": "2023-01-01"})
+        self.client.post(
+            "/workouts/1/heart_rate",
+            params={"timestamp": "2023-01-01T10:00:00", "heart_rate": 120},
+        )
+        self.client.post(
+            "/workouts/1/heart_rate",
+            params={"timestamp": "2023-01-01T10:05:00", "heart_rate": 150},
+        )
+
+        resp = self.client.get(
+            "/stats/heart_rate_zones",
+            params={"start_date": "2023-01-01", "end_date": "2023-01-02"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 5)
+        self.assertEqual(data[3]["count"], 1)
+        self.assertEqual(data[3]["percent"], 50.0)
+        self.assertEqual(data[4]["count"], 1)
+        self.assertEqual(data[4]["percent"], 50.0)
+
     def test_exercise_frequency(self) -> None:
         d1 = (datetime.date.today() - datetime.timedelta(days=7)).isoformat()
         d2 = datetime.date.today().isoformat()


### PR DESCRIPTION
## Summary
- implement `heart_rate_zones` in `StatisticsService`
- expose new `/stats/heart_rate_zones` endpoint
- document heart rate zone analytics in README
- test heart rate zone calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882546221548327bf966cf122573548