### PR TITLE
Add power history analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,3 +514,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Set pace analytics must compute sets per minute per workout and be available via `/stats/set_pace`.
 - Workout consistency analytics must compute the coefficient of variation of days between workouts and be available via `/stats/workout_consistency`.
 - Mobile layout must use a `--vh` CSS variable set via JavaScript in `_configure_page` for reliable viewport height across orientations.
+- Power history analytics must compute average power per day using weight and velocity and be available via `/stats/power_history`.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Assess workout variety with `/stats/exercise_diversity` and charts in the Reports tab.
 - Analyze training intensity zones with `/stats/intensity_distribution` displayed under Exercise Stats.
 - View velocity history per exercise with `/stats/velocity_history` and charts in the Stats tab.
+- View power output history per exercise with `/stats/power_history`.
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.
 - Summarize workouts by location with `/stats/location_summary` and view tables in the Reports tab.
 - Summarize workouts by training type with `/stats/training_type_summary`.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1210,6 +1210,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/power_history")
+        def stats_power_history(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.power_history(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/stats/overview")
         def stats_overview(
             start_date: str = None,

--- a/stats_service.py
+++ b/stats_service.py
@@ -608,6 +608,31 @@ class StatisticsService:
             result.append({"date": d, "velocity": round(avg, 2)})
         return result
 
+    def power_history(
+        self,
+        exercise: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Dict[str, float]]:
+        """Return average power per day for ``exercise``."""
+        names = self._alias_names(exercise)
+        rows = self.sets.fetch_history_by_names(
+            names,
+            start_date=start_date,
+            end_date=end_date,
+            with_duration=True,
+        )
+        by_date: Dict[str, List[float]] = {}
+        for reps, weight, _rpe, date, start, end in rows:
+            power = MathTools.estimate_power_from_set(int(reps), float(weight), start, end)
+            by_date.setdefault(date, []).append(power)
+        result: List[Dict[str, float]] = []
+        for d in sorted(by_date):
+            vals = by_date[d]
+            avg = sum(vals) / len(vals) if vals else 0.0
+            result.append({"date": d, "power": round(avg, 2)})
+        return result
+
     def overview(
         self,
         start_date: Optional[str] = None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1784,6 +1784,35 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(data[0]["date"], today)
         self.assertAlmostEqual(data[0]["velocity"], 0.5, places=2)
 
+    def test_power_history_endpoint(self) -> None:
+        today = datetime.date.today().isoformat()
+        self.client.post("/workouts", params={"date": today})
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        for i in range(2):
+            resp = self.client.post(
+                "/exercises/1/sets",
+                params={"reps": 5, "weight": 100.0, "rpe": 8},
+            )
+            set_id = resp.json()["id"]
+            start = f"2023-01-01T00:00:{i*5:02d}"
+            end = f"2023-01-01T00:00:{i*5+5:02d}"
+            self.client.post(f"/sets/{set_id}/start", params={"timestamp": start})
+            self.client.post(f"/sets/{set_id}/finish", params={"timestamp": end})
+
+        resp = self.client.get(
+            "/stats/power_history",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["date"], today)
+        expected = MathTools.estimate_power_from_set(5, 100.0, "2023-01-01T00:00:00", "2023-01-01T00:00:05")
+        self.assertAlmostEqual(data[0]["power"], round(expected, 2), places=2)
+
     def test_set_duration_endpoint(self) -> None:
         self.client.post("/workouts")
         self.client.post(

--- a/tools.py
+++ b/tools.py
@@ -102,6 +102,22 @@ class MathTools:
         return (reps * rom) / total_seconds
 
     @staticmethod
+    def estimate_power_from_set(
+        reps: int,
+        weight: float,
+        start_time: datetime.datetime | str,
+        finish_time: datetime.datetime | str,
+        rom: float = 0.5,
+    ) -> float:
+        """Estimate average mechanical power output for a set."""
+        velocity = MathTools.estimate_velocity_from_set(
+            reps, start_time, finish_time, rom
+        )
+        if velocity == 0.0:
+            return 0.0
+        return float(weight) * 9.81 * velocity
+
+    @staticmethod
     def session_efficiency(
         volume: float, duration_seconds: float, avg_rpe: float | None = None
     ) -> float:


### PR DESCRIPTION
## Summary
- implement `estimate_power_from_set` in `MathTools`
- provide `/stats/power_history` with `StatisticsService`
- expose the new endpoint in REST API
- test power history analytics and document the feature
- add rule about power history analytics in AGENTS

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688257e1008c8327971ea49cad0b2fb6