### PR TITLE
Add relative power history analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Analyze training intensity zones with `/stats/intensity_distribution` displayed under Exercise Stats.
 - View velocity history per exercise with `/stats/velocity_history` and charts in the Stats tab.
 - View power output history per exercise with `/stats/power_history`.
+- View relative power (W/kg) history per exercise with `/stats/relative_power_history`.
 - Summarize volume by muscle group with `/stats/muscle_group_usage`.
 - Summarize workouts by location with `/stats/location_summary` and view tables in the Reports tab.
 - Summarize workouts by training type with `/stats/training_type_summary`.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1222,6 +1222,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/relative_power_history")
+        def stats_relative_power_history(
+            exercise: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.relative_power_history(
+                exercise,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/stats/overview")
         def stats_overview(
             start_date: str = None,

--- a/stats_service.py
+++ b/stats_service.py
@@ -633,6 +633,34 @@ class StatisticsService:
             result.append({"date": d, "power": round(avg, 2)})
         return result
 
+    def relative_power_history(
+        self,
+        exercise: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Dict[str, float]]:
+        """Return average power to body weight ratio per day."""
+        body_weight = self._current_body_weight()
+        if body_weight <= 0:
+            return []
+        names = self._alias_names(exercise)
+        rows = self.sets.fetch_history_by_names(
+            names,
+            start_date=start_date,
+            end_date=end_date,
+            with_duration=True,
+        )
+        by_date: Dict[str, List[float]] = {}
+        for reps, weight, _rpe, date, start, end in rows:
+            power = MathTools.estimate_power_from_set(int(reps), float(weight), start, end)
+            by_date.setdefault(date, []).append(power / body_weight)
+        result: List[Dict[str, float]] = []
+        for d in sorted(by_date):
+            vals = by_date[d]
+            avg = sum(vals) / len(vals) if vals else 0.0
+            result.append({"date": d, "relative_power": round(avg, 2)})
+        return result
+
     def overview(
         self,
         start_date: Optional[str] = None,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3324,6 +3324,15 @@ class GymApp:
                             {"Velocity": [v["velocity"] for v in vel_hist]},
                             [v["date"] for v in vel_hist],
                         )
+                rel_power = self.stats.relative_power_history(
+                    ex_choice, start_str, end_str
+                )
+                if rel_power:
+                    with st.expander("Relative Power History", expanded=False):
+                        self._line_chart(
+                            {"Power/Weight": [p["relative_power"] for p in rel_power]},
+                            [p["date"] for p in rel_power],
+                        )
                 self._progress_forecast_section(ex_choice)
             self._volume_forecast_section(start_str, end_str)
         with rec_tab:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1813,6 +1813,35 @@ class APITestCase(unittest.TestCase):
         expected = MathTools.estimate_power_from_set(5, 100.0, "2023-01-01T00:00:00", "2023-01-01T00:00:05")
         self.assertAlmostEqual(data[0]["power"], round(expected, 2), places=2)
 
+    def test_relative_power_history_endpoint(self) -> None:
+        today = datetime.date.today().isoformat()
+        self.client.post("/workouts", params={"date": today})
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        for i in range(2):
+            resp = self.client.post(
+                "/exercises/1/sets",
+                params={"reps": 5, "weight": 100.0, "rpe": 8},
+            )
+            set_id = resp.json()["id"]
+            start = f"2023-01-01T00:00:{i*5:02d}"
+            end = f"2023-01-01T00:00:{i*5+5:02d}"
+            self.client.post(f"/sets/{set_id}/start", params={"timestamp": start})
+            self.client.post(f"/sets/{set_id}/finish", params={"timestamp": end})
+
+        resp = self.client.get(
+            "/stats/relative_power_history",
+            params={"exercise": "Bench Press"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["date"], today)
+        expected = MathTools.estimate_power_from_set(5, 100.0, "2023-01-01T00:00:00", "2023-01-01T00:00:05") / 80.0
+        self.assertAlmostEqual(data[0]["relative_power"], round(expected, 2), places=2)
+
     def test_set_duration_endpoint(self) -> None:
         self.client.post("/workouts")
         self.client.post(


### PR DESCRIPTION
## Summary
- implement `relative_power_history` in `StatisticsService`
- expose new `/stats/relative_power_history` endpoint
- display Relative Power History chart in Progress tab
- document new endpoint in README
- test new endpoint via REST API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825b82ffa48327998125605ccb3129