### PR TITLE
Add workout streak gamification

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -94,6 +94,7 @@ class GymAPI:
             self.game_repo,
             self.exercises,
             self.settings,
+            self.workouts,
         )
         self.ml_service = PerformanceModelService(
             self.ml_models,
@@ -1428,6 +1429,10 @@ class GymAPI:
                 {"workout_id": wid, "points": pts}
                 for wid, pts in self.gamification.points_by_workout()
             ]
+
+        @self.app.get("/gamification/streak")
+        def gamification_streak():
+            return self.gamification.workout_streak()
 
         @self.app.get("/utils/warmup_weights")
         def utils_warmup_weights(target_weight: float, sets: int = 3):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -203,6 +203,7 @@ class GymApp:
             self.game_repo,
             self.exercises,
             self.settings_repo,
+            self.workouts,
         )
         self.ml_service = PerformanceModelService(
             self.ml_models,
@@ -3707,6 +3708,14 @@ class GymApp:
                     {"Points": [p[1] for p in data]},
                     [str(p[0]) for p in data],
                 )
+        streak = self.gamification.workout_streak()
+        with st.expander("Streak", expanded=True):
+            self._metric_grid(
+                [
+                    ("Current Streak", streak["current"]),
+                    ("Record Streak", streak["record"]),
+                ]
+            )
 
     def _tests_tab(self) -> None:
         st.header("Pyramid Test")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2958,6 +2958,15 @@ class APITestCase(unittest.TestCase):
         status = self.client.get("/autoplanner/status").json()
         self.assertTrue(any(m["name"] == "volume_model" for m in status["models"]))
 
+    def test_workout_streak_endpoint(self) -> None:
+        today = datetime.date.today()
+        for i in range(3):
+            date = (today - datetime.timedelta(days=2 - i)).isoformat()
+            self.client.post("/workouts", params={"date": date})
+        resp = self.client.get("/gamification/streak")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"current": 3, "record": 3})
+
         # disable both training and prediction
         resp = self.client.post(
             "/settings/general",

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -519,7 +519,7 @@ class StreamlitFullGUITest(unittest.TestCase):
     def test_gamification_tab(self) -> None:
         tab = self._get_tab("Gamification")
         self.assertEqual(tab.header[0].value, "Gamification Stats")
-        self.assertGreater(len(tab.metric), 0)
+        self.assertGreaterEqual(len(tab.metric), 2)
 
     def test_tests_tab(self) -> None:
         tab = self._get_tab("Tests")


### PR DESCRIPTION
## Summary
- extend `GamificationService` with workout streak calculation
- expose `/gamification/streak` endpoint
- show streak metrics in gamification tab
- test new endpoint and GUI metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68825f65aca0832787b4fa57d1845468