### PR TITLE
Add warmup set planning feature

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -60,6 +60,12 @@ class MathToolsTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             MathTools.warmup_weights(-1.0, 3)
 
+    def test_warmup_plan(self) -> None:
+        plan = MathTools.warmup_plan(100.0, 5, 2)
+        self.assertEqual(plan, [(7, 30.0), (2, 60.0)])
+        with self.assertRaises(ValueError):
+            MathTools.warmup_plan(-1.0, 5, 2)
+
     def test_session_density(self) -> None:
         val = MathTools.session_density(1000.0, 600)
         self.assertAlmostEqual(val, 100.0)

--- a/tools.py
+++ b/tools.py
@@ -83,6 +83,15 @@ class MathTools:
         return [round(target_weight * float(i), 2) for i in inc]
 
     @staticmethod
+    def warmup_plan(target_weight: float, target_reps: int, sets: int = 3) -> list[tuple[int, float]]:
+        """Generate a warmup plan as list of (reps, weight)."""
+        if target_weight <= 0 or target_reps <= 0 or sets <= 0:
+            raise ValueError("invalid input values")
+        weights = MathTools.warmup_weights(target_weight, sets)
+        rep_range = np.linspace(target_reps + 2, max(1, target_reps // 2), sets)
+        return [(int(round(r)), w) for r, w in zip(rep_range, weights)]
+
+    @staticmethod
     def estimate_velocity_from_set(
         reps: int,
         start_time: datetime.datetime | str,


### PR DESCRIPTION
## Summary
- add warmup flag to sets table
- extend SetRepository and REST API to handle warmup sets
- implement warmup set generation algorithm
- expose warmup utilities endpoints and GUI controls
- update tests for new warmup functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688268b0b8708327b753d74f0b8a02e1