### PR TITLE
Add header help button

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1316,6 +1316,8 @@ class GymApp:
             self.theme = new_theme
             self._apply_theme()
             st.rerun()
+        if st.button("Help", key="help_button_header"):
+            self._help_dialog()
         st.markdown("</div>", unsafe_allow_html=True)
         self._top_nav()
         self._close_header()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -418,6 +418,14 @@ class StreamlitAppTest(unittest.TestCase):
             data = yaml.safe_load(f)
         self.assertEqual(data["theme"], "dark")
 
+    def test_help_header_button(self) -> None:
+        idx = _find_by_label(self.at.button, "Help", key="help_button_header")
+        self.at.button[idx].click().run()
+        help_text = any(
+            "Workout Logger Help" in m.body for m in self.at.markdown
+        )
+        self.assertTrue(help_text)
+
     def test_git_pull_button(self) -> None:
         self.at.query_params["tab"] = "settings"
         self.at.run()


### PR DESCRIPTION
## Summary
- improve ease of use with a Help button in the page header
- extend GUI tests to cover the new button

## Testing
- `pytest tests/test_streamlit_app.py tests/test_mobile_css.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688339cf10288327a0ad8fa1059643a3