### PR TITLE
Improve GUI with filter reset buttons

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1167,6 +1167,23 @@ class GymApp:
             st.session_state.scroll_to = self._slugify(choice)
             st.rerun()
 
+    def _reset_equipment_filters(self) -> None:
+        """Clear equipment library filter inputs."""
+        st.session_state.lib_eq_type = ""
+        st.session_state.lib_eq_prefix = ""
+        st.session_state.lib_eq_mus = []
+        if os.environ.get("TEST_MODE") != "1":
+            st.rerun()
+
+    def _reset_exercise_filters(self) -> None:
+        """Clear exercise library filter inputs."""
+        st.session_state.lib_ex_groups = []
+        st.session_state.lib_ex_mus = []
+        st.session_state.lib_ex_eq = ""
+        st.session_state.lib_ex_prefix = ""
+        if os.environ.get("TEST_MODE") != "1":
+            st.rerun()
+
     def _help_dialog(self) -> None:
         def _content() -> None:
             st.markdown("## Workout Logger Help")
@@ -2744,6 +2761,8 @@ class GymApp:
                 sel_type = st.selectbox("Type", types, key="lib_eq_type")
                 prefix = st.text_input("Name Contains", key="lib_eq_prefix")
                 mus_filter = st.multiselect("Muscles", muscles, key="lib_eq_mus")
+                if st.button("Reset Filters", key="lib_eq_reset"):
+                    self._reset_equipment_filters()
             names = self.equipment.fetch_names(
                 sel_type or None,
                 prefix or None,
@@ -2769,6 +2788,8 @@ class GymApp:
                 sel_type = st.selectbox("Type", types, key="lib_eq_type")
                 prefix = st.text_input("Name Contains", key="lib_eq_prefix")
                 mus_filter = st.multiselect("Muscles", muscles, key="lib_eq_mus")
+                if st.button("Reset Filters", key="lib_eq_reset"):
+                    self._reset_equipment_filters()
             names = self.equipment.fetch_names(
                 sel_type or None,
                 prefix or None,
@@ -2824,6 +2845,8 @@ class GymApp:
             eq_names = self.equipment.fetch_names()
             sel_eq = st.selectbox("Equipment", [""] + eq_names, key="lib_ex_eq")
             name_filter = st.text_input("Name Contains", key="lib_ex_prefix")
+            if st.button("Reset Filters", key="lib_ex_reset"):
+                self._reset_exercise_filters()
             names = self.exercise_catalog.fetch_names(
                 sel_groups or None,
                 sel_mus or None,
@@ -2878,6 +2901,8 @@ class GymApp:
                     eq_names = self.equipment.fetch_names()
                     sel_eq = st.selectbox("Equipment", [""] + eq_names, key="lib_ex_eq")
                     name_filter = st.text_input("Name Contains", key="lib_ex_prefix")
+                    if st.button("Reset Filters", key="lib_ex_reset"):
+                        self._reset_exercise_filters()
             names = self.exercise_catalog.fetch_names(
                 sel_groups or None,
                 sel_mus or None,

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -170,6 +170,16 @@ class StreamlitAppTest(unittest.TestCase):
         ex_tab = self.at.tabs[5]
         self.assertIn("Barbell Bench Press", ex_tab.selectbox[2].options)
 
+    def test_reset_buttons_present(self) -> None:
+        self.at.query_params["tab"] = "library"
+        self.at.run()
+        eq_tab = self.at.tabs[4]
+        idx_eq = _find_by_label(eq_tab.button, "Reset Filters", key="lib_eq_reset")
+        self.assertIsNotNone(idx_eq)
+        ex_tab = self.at.tabs[5]
+        idx_ex = _find_by_label(ex_tab.button, "Reset Filters", key="lib_ex_reset")
+        self.assertIsNotNone(idx_ex)
+
     def test_custom_exercise_and_logs(self) -> None:
         self.at.query_params["tab"] = "settings"
         self.at.run()


### PR DESCRIPTION
## Summary
- add reset button for equipment filters
- add reset button for exercise filters
- expose helper methods to clear filter inputs
- test that reset buttons appear in library tabs

## Testing
- `pytest tests/test_streamlit_app.py tests/test_mobile_css.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68834630243c83279bfbe10c18dd4cc2