### PR TITLE
Improve workout plan tab UX

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1462,44 +1462,38 @@ class GymApp:
             self._exercise_section()
 
     def _plan_tab(self) -> None:
-        ai_tab, tmpl_tab, plan_tab = st.tabs([
-            "AI Planner",
-            "Templates",
-            "Planned Workouts",
-        ])
-        with ai_tab:
-            with st.expander("AI Generated Plan", expanded=False):
-                ai_date = st.date_input(
-                    "Plan Date", datetime.date.today(), key="ai_plan_date"
-                )
-                names = self.exercise_catalog.fetch_names(None, None, None, None)
-                ex_sel = st.multiselect(
-                    "Exercises", names, key="ai_plan_exercises"
-                )
-                ai_type = st.selectbox(
-                    "Training Type",
-                    self.training_options,
-                    index=self.training_options.index("strength"),
-                    key="ai_plan_type",
-                )
-                if st.button("Generate AI Plan", key="ai_plan_btn"):
-                    if ex_sel:
-                        pairs = [(n, None) for n in ex_sel]
-                        try:
-                            pid = self.planner.create_ai_plan(
-                                ai_date.isoformat(), pairs, ai_type
-                            )
-                            st.session_state.selected_planned_workout = pid
-                            st.success("Plan created")
-                        except ValueError as e:
-                            st.warning(str(e))
-                    else:
-                        st.warning("Select exercises")
-        with tmpl_tab:
+        with st.expander("AI Planner", expanded=False):
+            ai_date = st.date_input(
+                "Plan Date", datetime.date.today(), key="ai_plan_date"
+            )
+            names = self.exercise_catalog.fetch_names(None, None, None, None)
+            ex_sel = st.multiselect(
+                "Exercises", names, key="ai_plan_exercises"
+            )
+            ai_type = st.selectbox(
+                "Training Type",
+                self.training_options,
+                index=self.training_options.index("strength"),
+                key="ai_plan_type",
+            )
+            if st.button("Generate AI Plan", key="ai_plan_btn"):
+                if ex_sel:
+                    pairs = [(n, None) for n in ex_sel]
+                    try:
+                        pid = self.planner.create_ai_plan(
+                            ai_date.isoformat(), pairs, ai_type
+                        )
+                        st.session_state.selected_planned_workout = pid
+                        st.success("Plan created")
+                    except ValueError as e:
+                        st.warning(str(e))
+                else:
+                    st.warning("Select exercises")
+        with st.expander("Templates", expanded=False):
             self._template_section()
             if st.session_state.get("selected_template") is not None:
                 self._template_exercise_section()
-        with plan_tab:
+        with st.expander("Planned Workouts", expanded=True):
             self._planned_workout_section()
             if st.session_state.selected_planned_workout:
                 self._planned_exercise_section()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -603,7 +603,7 @@ class StreamlitFullGUITest(unittest.TestCase):
         self.at.query_params["tab"] = "workouts"
         self.at.run()
         plan_tab = self._get_tab("Plan")
-        labels = [t.label for t in plan_tab.tabs]
+        labels = [e.label for e in plan_tab.expander]
         for name in ["AI Planner", "Templates", "Planned Workouts"]:
             self.assertIn(name, labels)
 
@@ -719,16 +719,24 @@ class StreamlitTemplateWorkflowTest(unittest.TestCase):
     def _connect(self) -> sqlite3.Connection:
         return sqlite3.connect(self.db_path)
 
+    def _get_tab(self, label: str):
+        for tab in self.at.tabs:
+            if tab.label == label:
+                return tab
+        self.fail(f"Tab {label} not found")
+
     def test_template_plan_to_workout(self) -> None:
-        tmpl_tab = next(t for t in self.at.tabs if t.label == "Templates")
-        tmpl_tab.text_input[0].input("Tpl1").run()
-        idx = _find_by_label(tmpl_tab.selectbox, "Training Type")
-        tmpl_tab.selectbox[idx].select("strength").run()
-        b_idx = _find_by_label(tmpl_tab.button, "Create Template")
-        tmpl_tab.button[b_idx].click().run()
+        plan_tab = self._get_tab("Plan")
+        tmpl_exp = next(e for e in plan_tab.expander if e.label == "Templates")
+        tmpl_exp.text_input[0].input("Tpl1").run()
+        idx = _find_by_label(tmpl_exp.selectbox, "Training Type")
+        tmpl_exp.selectbox[idx].select("strength").run()
+        b_idx = _find_by_label(tmpl_exp.button, "Create Template")
+        tmpl_exp.button[b_idx].click().run()
         self.at.run()
-        tmpl_tab = next(t for t in self.at.tabs if t.label == "Templates")
-        for exp in tmpl_tab.expander:
+        plan_tab = self._get_tab("Plan")
+        tmpl_exp = next(e for e in plan_tab.expander if e.label == "Templates")
+        for exp in tmpl_exp.expander:
             if exp.label.startswith("Tpl1"):
                 exp.button[1].click().run()
                 break


### PR DESCRIPTION
## Summary
- restructure Plan tab using expanders instead of nested tabs
- adapt GUI tests to check new layout

## Testing
- `pytest -k 'streamlit_app or mobile_css' -q`

------
https://chatgpt.com/codex/tasks/task_e_68835c03b1ac8327853091366391e509