### PR TITLE
Improve workout selection usability

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,6 +3,7 @@ import pandas as pd
 from contextlib import contextmanager
 from typing import Optional, Generator, Callable
 import streamlit as st
+import streamlit.components.v1 as components
 import altair as alt
 from altair.utils.deprecation import AltairDeprecationWarning
 import warnings
@@ -131,7 +132,7 @@ class LayoutManager:
 
     def scroll_to(self, element_id: str) -> None:
         """Scroll smoothly to the element with the given id."""
-        st.components.v1.html(
+        components.html(
             f"<script>document.getElementById('{element_id}')?.scrollIntoView({{behavior:'smooth'}});</script>",
             height=0,
         )
@@ -272,7 +273,7 @@ class GymApp:
         params = st.query_params
         mode = params.get("mode")
         if mode is None:
-            st.components.v1.html(
+            components.html(
                 """
                 <script>
                 const mode = Math.min(window.innerWidth, window.innerHeight) < 768 ? 'mobile' : 'desktop';
@@ -292,7 +293,7 @@ class GymApp:
         )
         st.session_state.layout_set = True
         st.session_state.is_mobile = mode == "mobile"
-        st.components.v1.html(
+        components.html(
             """
             <script>
             function setMode() {
@@ -1536,9 +1537,18 @@ class GymApp:
 
     def _existing_workout_form(self, training_options: list[str]) -> None:
         with st.expander("Existing Workouts", expanded=True):
+            search = st.text_input("Search", key="workout_search")
+            if st.button("Reset Search", key="workout_search_reset"):
+                st.session_state.workout_search = ""
+                st.rerun()
             workouts = sorted(
                 self.workouts.fetch_all_workouts(), key=lambda w: w[1]
             )
+            if search:
+                query = search.lower()
+                workouts = [
+                    w for w in workouts if query in (w[5] or "").lower()
+                ]
             options = {str(w[0]): w for w in workouts}
             if options:
                 selected = st.selectbox(

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -110,6 +110,30 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertIsNotNone(end_time)
         conn.close()
 
+    def test_workout_search(self) -> None:
+        loc_idx = _find_by_label(
+            self.at.text_input,
+            "Location",
+            key="new_workout_location",
+        )
+        self.at.text_input[loc_idx].input("Home Workout").run()
+        new_idx = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[new_idx].click().run()
+        self.at.text_input[loc_idx].input("Gym Workout").run()
+        self.at.button[new_idx].click().run()
+        exp_idx = _find_by_label(self.at.expander, "Existing Workouts")
+        ex_exp = self.at.expander[exp_idx]
+        s_idx = _find_by_label(ex_exp.text_input, "Search", key="workout_search")
+        ex_exp.text_input[s_idx].input("Gym").run()
+        self.at.run()
+        ex_exp = self.at.expander[exp_idx]
+        options = ex_exp.selectbox[0].options
+        self.assertEqual(options, ["2"])
+
     def test_jump_to_section_selectbox(self) -> None:
         idx = _find_by_label(
             self.at.selectbox, "Jump to Section", key="log_jump"


### PR DESCRIPTION
## Summary
- add search box and reset button to filter existing workouts
- adjust JS injection using `components.html`
- extend GUI tests for workout search

## Testing
- `pytest tests/test_streamlit_app.py tests/test_mobile_css.py -q` *(fails: ModuleNotFoundError, StreamlitAPIException)*

------
https://chatgpt.com/codex/tasks/task_e_688361a16878832783c8ae8ba4055b48