### PR TITLE
Improve workout search usability

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1537,10 +1537,13 @@ class GymApp:
 
     def _existing_workout_form(self, training_options: list[str]) -> None:
         with st.expander("Existing Workouts", expanded=True):
-            search = st.text_input("Search", key="workout_search")
-            if st.button("Reset Search", key="workout_search_reset"):
-                st.session_state.workout_search = ""
-                st.rerun()
+            c1, c2 = st.columns([3, 1])
+            with c1:
+                search = st.text_input("Search", key="workout_search")
+            with c2:
+                if st.button("Reset Search", key="workout_search_reset"):
+                    st.session_state.workout_search = ""
+                    st.rerun()
             workouts = sorted(
                 self.workouts.fetch_all_workouts(), key=lambda w: w[1]
             )
@@ -1657,6 +1660,8 @@ class GymApp:
                 )
                 if st.button("Delete Workout", key=f"del_workout_{selected}"):
                     self._confirm_delete_workout(int(selected))
+            else:
+                st.info("No workouts found.")
 
     def _planned_workout_section(self) -> None:
         with self._section("Planned Workouts"):

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -110,6 +110,12 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertIsNotNone(end_time)
         conn.close()
 
+    def test_no_workouts_message(self) -> None:
+        exp_idx = _find_by_label(self.at.expander, "Existing Workouts")
+        exp = self.at.expander[exp_idx]
+        texts = [i.body for i in getattr(exp, "info", [])]
+        self.assertIn("No workouts found.", texts)
+
     def test_workout_search(self) -> None:
         loc_idx = _find_by_label(
             self.at.text_input,


### PR DESCRIPTION
## Summary
- show search input and reset button on one row
- notify users when no workouts are found
- test the new no-workout message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c3d67cd88327bd1e373377ba72fa