### PR TITLE
Enhance GUI with sidebar search

### DIFF
--- a/db.py
+++ b/db.py
@@ -751,6 +751,15 @@ class WorkoutRepository(BaseRepository):
             (note, workout_id),
         )
 
+    def search(self, query: str) -> list[tuple[int, str]]:
+        """Return workouts where notes or location match the query."""
+        like = f"%{query.lower()}%"
+        rows = self.fetch_all(
+            "SELECT id, date FROM workouts WHERE lower(notes) LIKE ? OR lower(location) LIKE ? ORDER BY id DESC;",
+            (like, like),
+        )
+        return [(wid, date) for wid, date in rows]
+
     def delete_all(self) -> None:
         self._delete_all("workouts")
 

--- a/rest_api.py
+++ b/rest_api.py
@@ -542,6 +542,11 @@ class GymAPI:
             workouts = self.workouts.fetch_all_workouts(start_date, end_date)
             return [{"id": wid, "date": date} for wid, date, *_ in workouts]
 
+        @self.app.get("/workouts/search")
+        def search_workouts(query: str):
+            rows = self.workouts.search(query)
+            return [{"id": wid, "date": date} for wid, date in rows]
+
         @self.app.get("/workouts/history")
         def workout_history(
             start_date: str,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1089,6 +1089,21 @@ class GymApp:
                 self._help_dialog()
             if st.button("Show About", key="about_btn"):
                 self._about_dialog()
+        with st.sidebar.expander("Quick Search"):
+            query = st.text_input("Search", key="sidebar_search")
+            if st.button("Search", key="sidebar_search_btn"):
+                st.session_state.sidebar_search_results = (
+                    self.workouts.search(query) if query else []
+                )
+            results = st.session_state.get("sidebar_search_results", [])
+            if results:
+                options = {f"{wid} - {date}": wid for wid, date in results}
+                choice = st.selectbox(
+                    "Results", list(options.keys()), key="sidebar_search_sel"
+                )
+                if st.button("Open", key="sidebar_search_open"):
+                    st.session_state.selected_workout = options[choice]
+                    self._switch_tab("workouts")
 
     def _render_nav(self, container_class: str) -> None:
         """Render navigation bar using LayoutManager."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2992,6 +2992,14 @@ class APITestCase(unittest.TestCase):
         status = self.client.get("/autoplanner/status").json()
         self.assertTrue(any(m["name"] == "volume_model" for m in status["models"]))
 
+    def test_workout_search_endpoint(self) -> None:
+        today = datetime.date.today().isoformat()
+        self.client.post("/workouts", params={"notes": "Home session"})
+        self.client.post("/workouts", params={"notes": "Gym session"})
+        resp = self.client.get("/workouts/search", params={"query": "Gym"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), [{"id": 2, "date": today}])
+
     def test_workout_streak_endpoint(self) -> None:
         today = datetime.date.today()
         for i in range(3):

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -769,6 +769,24 @@ class StreamlitAdditionalGUITest(unittest.TestCase):
         self.assertEqual(cur.fetchone()[0], 1)
         conn.close()
 
+    def test_sidebar_quick_search(self) -> None:
+        idx_new = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[idx_new].click().run()
+        self.at.button[idx_new].click().run()
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("UPDATE workouts SET notes='Home' WHERE id=1")
+        cur.execute("UPDATE workouts SET notes='Gym' WHERE id=2")
+        conn.commit()
+        conn.close()
+        exp_idx = _find_by_label(self.at.sidebar.expander, "Quick Search")
+        exp = self.at.sidebar.expander[exp_idx]
+        self.assertEqual(exp.button[0].label, "Search")
+
 
 class StreamlitTemplateWorkflowTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
- support searching workouts by notes or location
- expose search via `/workouts/search` endpoint
- add quick search expander to sidebar
- test new REST search and GUI element

## Testing
- `pytest tests/test_streamlit_app.py::StreamlitAdditionalGUITest::test_sidebar_quick_search -q`
- `pytest tests/test_mobile_css.py -q`
- `pytest tests/test_api.py::APITestCase::test_workout_search_endpoint -q`
- `pytest tests/test_streamlit_app.py tests/test_mobile_css.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d59d81588327a849c0da3f2ca087