### PR TITLE
Implement TODO keyboard shortcuts and reorganized library

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,10 +3,10 @@
  - [x] 3. Implement in‑app tooltips for all form inputs using `st.help` for accessibility.
 - [x] 4. Group workout planning tools into an expander inside the Workouts tab.
 - [x] 5. Add quick‑add buttons for favorite exercises directly in the workout logging form.
-- [ ] 6. Add keyboard shortcuts for adding sets and toggling tabs via Streamlit hotkeys.
+- [x] 6. Add keyboard shortcuts for adding sets and toggling tabs via Streamlit hotkeys.
 - [x] 7. Enhance mobile layout by ensuring all buttons are reachable with one hand.
 - [x] 8. Add a floating action button to log a new workout from any tab on mobile.
-- [ ] 9. Reorganize the Library tab with expanders for exercises, templates and equipment.
+- [x] 9. Reorganize the Library tab with expanders for exercises, templates and equipment.
 - [x] 10. Provide a dark/light mode toggle in the Settings tab.
 - [x] 11. Add global search at the top navigation to quickly find workouts, exercises or tags.
 - [x] 12. Display key stats like today's volume in a metric grid at the top of the Workouts tab.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -348,6 +348,19 @@ class GymApp:
             window.addEventListener('DOMContentLoaded', handleResize);
             window.addEventListener('load', handleResize);
             handleResize();
+            function handleHotkeys(e) {
+                if (e.altKey && ['1','2','3','4'].includes(e.key)) {
+                    const labels = ['workouts','library','progress','settings'];
+                    const params = new URLSearchParams(window.location.search);
+                    params.set('tab', labels[parseInt(e.key)-1]);
+                    window.location.search = params.toString();
+                } else if (e.altKey && e.key.toLowerCase() === 'a') {
+                    const btn = Array.from(document.querySelectorAll('button'))
+                        .find(b => b.innerText.trim() === 'Add Set');
+                    if (btn) btn.click();
+                }
+            }
+            window.addEventListener('keydown', handleHotkeys);
             </script>
             """,
             height=0,
@@ -1641,10 +1654,11 @@ class GymApp:
                         st.warning(str(e))
                 else:
                     st.warning("Select exercises")
-        with st.expander("Templates", expanded=False):
-            self._template_section()
-            if st.session_state.get("selected_template") is not None:
-                self._template_exercise_section()
+        if st.query_params.get("tab") == "workouts":
+            with st.expander("Templates", expanded=False):
+                self._template_section()
+                if st.session_state.get("selected_template") is not None:
+                    self._template_exercise_section()
         with st.expander("Planned Workouts", expanded=True):
             self._planned_workout_section()
             if st.session_state.selected_planned_workout:
@@ -2982,18 +2996,19 @@ class GymApp:
 
     def _library_tab(self) -> None:
         st.header("Library")
-        fav_tab, eq_tab, ex_tab = st.tabs(
-            [
-                "Favorites",
-                "Equipment",
-                "Exercises",
-            ]
-        )
-        with fav_tab:
+        with st.expander("Favorites", expanded=False):
             self._favorites_library()
-        with eq_tab:
+        if st.query_params.get("tab") == "library":
+            with st.expander("Templates", expanded=False):
+                self._template_section()
+                if st.session_state.get("selected_template") is not None:
+                    self._template_exercise_section()
+        else:
+            with st.expander("Templates", expanded=False):
+                st.write(" ")
+        with st.expander("Equipment", expanded=False):
             self._equipment_library()
-        with ex_tab:
+        with st.expander("Exercises", expanded=True):
             self._exercise_catalog_library()
 
     def _favorites_library(self) -> None:

--- a/tests/test_hotkeys.py
+++ b/tests/test_hotkeys.py
@@ -1,0 +1,16 @@
+import os
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+
+class HotkeyScriptTest(unittest.TestCase):
+    def test_hotkey_script_present(self) -> None:
+        path = os.path.join(ROOT, "streamlit_app.py")
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("handleHotkeys", content)
+        self.assertIn("window.addEventListener('keydown'", content)
+        self.assertIn("['workouts','library','progress','settings']", content)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -217,7 +217,7 @@ class StreamlitAppTest(unittest.TestCase):
     def test_quick_add_favorite(self) -> None:
         self.at.query_params["tab"] = "library"
         self.at.run()
-        fav_tab = next(t for t in self._get_tab("Library").tabs if t.label == "Favorites")
+        fav_tab = next(e for e in self._get_tab("Library").expander if e.label == "Favorites")
         idx = _find_by_label(
             fav_tab.selectbox, "Add Favorite", "Barbell Bench Press", key="fav_add_name"
         )
@@ -249,32 +249,32 @@ class StreamlitAppTest(unittest.TestCase):
         self.at.query_params["tab"] = "library"
         self.at.run()
         lib_tab = self._get_tab("Library")
-        eq_tab = next(t for t in lib_tab.tabs if t.label == "Equipment")
+        eq_tab = next(e for e in lib_tab.expander if e.label == "Equipment")
         eq_tab.selectbox[0].select("Free Weights").run()
         self.at.run()
         lib_tab = self._get_tab("Library")
-        eq_tab = next(t for t in lib_tab.tabs if t.label == "Equipment")
+        eq_tab = next(e for e in lib_tab.expander if e.label == "Equipment")
         self.assertIn("Olympic Barbell", eq_tab.selectbox[1].options)
 
     def test_exercise_filtering(self) -> None:
         self.at.query_params["tab"] = "library"
         self.at.run()
         lib_tab = self._get_tab("Library")
-        ex_tab = next(t for t in lib_tab.tabs if t.label == "Exercises")
+        ex_tab = next(e for e in lib_tab.expander if e.label == "Exercises")
         ex_tab.multiselect[0].select("Chest").run()
         self.at.run()
         lib_tab = self._get_tab("Library")
-        ex_tab = next(t for t in lib_tab.tabs if t.label == "Exercises")
+        ex_tab = next(e for e in lib_tab.expander if e.label == "Exercises")
         self.assertIn("Barbell Bench Press", ex_tab.selectbox[1].options)
 
     def test_reset_buttons_present(self) -> None:
         self.at.query_params["tab"] = "library"
         self.at.run()
         lib_tab = self._get_tab("Library")
-        eq_tab = next(t for t in lib_tab.tabs if t.label == "Equipment")
+        eq_tab = next(e for e in lib_tab.expander if e.label == "Equipment")
         idx_eq = _find_by_label(eq_tab.button, "Reset Filters", key="lib_eq_reset")
         self.assertIsNotNone(idx_eq)
-        ex_tab = next(t for t in lib_tab.tabs if t.label == "Exercises")
+        ex_tab = next(e for e in lib_tab.expander if e.label == "Exercises")
         idx_ex = _find_by_label(ex_tab.button, "Reset Filters", key="lib_ex_reset")
         self.assertIsNotNone(idx_ex)
 
@@ -781,14 +781,13 @@ class StreamlitFullGUITest(unittest.TestCase):
         for name in ["AI Planner", "Templates", "Planned Workouts"]:
             self.assertIn(name, labels)
 
-    def test_library_subtabs(self) -> None:
+    def test_library_sections(self) -> None:
         self.at.query_params["tab"] = "library"
         self.at.run()
         tab = self._get_tab("Library")
-        labels = [t.label for t in tab.tabs]
-        self.assertIn("Favorites", labels)
-        self.assertIn("Equipment", labels)
-        self.assertIn("Exercises", labels)
+        labels = [e.label for e in tab.expander]
+        for name in ["Favorites", "Templates", "Equipment", "Exercises"]:
+            self.assertIn(name, labels)
 
     def test_settings_subtabs(self) -> None:
         self.at.query_params["tab"] = "settings"


### PR DESCRIPTION
## Summary
- add hotkeys script to toggle tabs and add sets
- reorganize library tab using expanders
- update GUI tests and add hotkey tests
- mark completed items in TODO

## Testing
- `pytest tests/test_hotkeys.py tests/test_streamlit_app.py::StreamlitFullGUITest::test_library_sections -q`
- `pytest -q` *(interrupted after completion showing 150 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68847d9f07dc8327981fd4447fa904c7