### PR TITLE
Implement weekly email reports

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,7 +60,7 @@
 - [x] 57. Show progress indicators when syncing settings with `settings.yaml`.
 - [x] 58. Add avatar and profile management with an image upload field in settings.
 - [x] 59. Provide a summary banner after logging a workout with key statistics.
-- [ ] 60. Implement optional email export of weekly reports triggered via settings.
+- [x] 60. Implement optional email export of weekly reports triggered via settings.
 - [ ] 61. Consolidate progress charts into a carousel for easier comparison.
 - [x] 62. Add haptic feedback on mobile when logging sets.
 - [ ] 63. Create contextual menus on right click for quick actions on workouts.


### PR DESCRIPTION
## Summary
- add new `email_logs` table and repository
- allow configuring weekly report emails in settings
- expose `/reports/email_weekly` and `/reports/email_logs` endpoints
- test weekly email report API
- mark TODO item for weekly email reports as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688606b8ff948327a81d6aba60f316f0