### PR TITLE
Implement quick weight buttons and weekly streak analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Builder is a full featured workout planner, logger and analytics platform bu
 - Evaluate exercise frequency per week with `/stats/exercise_frequency`.
 - Evaluate workout schedule consistency with `/stats/workout_consistency` displayed in Reports.
 - Analyze week-over-week volume change with `/stats/weekly_volume_change` displayed in the Reports tab.
+- Track weekly workout streaks with `/stats/weekly_streak` and view metrics in Progress Summary.
 - Track body weight over time using `/body_weight` endpoints and `/stats/weight_stats`.
 - Forecast future body weight trends with `/stats/weight_forecast`.
 - View weight history, BMI charts and forecasts in the Progress tab's new "Body Weight" section.

--- a/TODO.md
+++ b/TODO.md
@@ -81,8 +81,8 @@
 - [ ] 78. Implement lazy loading for long tables to improve performance.
 - [ ] 79. Include a widget to display ongoing challenges and achievements.
 - [ ] 80. Add undo/redo controls for workout editing actions.
-- [ ] 81. Provide customizable quick-add weight values for faster input.
-- [ ] 82. Show weekly streak counters on the Progress tab.
+- [x] 81. Provide customizable quick-add weight values for faster input.
+- [x] 82. Show weekly streak counters on the Progress tab.
  - [x] 83. Offer automatic dark mode based on system preferences.
 - [ ] 84. Introduce a split view on tablets to show history and logging side by side.
 - [ ] 85. Add persistent toolbars within expanders for common actions.

--- a/db.py
+++ b/db.py
@@ -645,6 +645,7 @@ class Database:
             "weekly_report_email": "",
             "weight_unit": "kg",
             "time_format": "24h",
+            "quick_weights": "20,40,60,80,100",
         }
         with self._connection() as conn:
             for key, value in defaults.items():

--- a/rest_api.py
+++ b/rest_api.py
@@ -1490,6 +1490,10 @@ class GymAPI:
         ):
             return self.statistics.workout_consistency(start_date, end_date)
 
+        @self.app.get("/stats/weekly_streak")
+        def stats_weekly_streak():
+            return self.statistics.weekly_streak()
+
         @self.app.get("/stats/volume_forecast")
         def stats_volume_forecast(
             days: int = 7,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1868,6 +1868,21 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(data[0]["week"], d2)
         self.assertAlmostEqual(data[0]["change"], 100.0, places=2)
 
+    def test_weekly_streak_endpoint(self) -> None:
+        dates = [
+            "2024-01-01",
+            "2024-01-08",
+            "2024-01-15",
+            "2024-02-05",
+        ]
+        for d in dates:
+            self.client.post("/workouts", params={"date": d})
+        resp = self.client.get("/stats/weekly_streak")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["current"], 1)
+        self.assertEqual(data["best"], 3)
+
     def test_set_velocity_and_history(self) -> None:
         self.client.post("/workouts")
         self.client.post(

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -310,6 +310,30 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertEqual(cur.fetchone()[0], "Barbell Bench Press")
         conn.close()
 
+    def test_quick_weight_buttons(self) -> None:
+        idx_new = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[idx_new].click().run()
+        idx_ex = _find_by_label(self.at.selectbox, "Exercise", "Barbell Bench Press")
+        self.at.selectbox[idx_ex].select("Barbell Bench Press").run()
+        idx_eq = _find_by_label(self.at.selectbox, "Equipment Name", "Olympic Barbell")
+        self.at.selectbox[idx_eq].select("Olympic Barbell").run()
+        idx_add_ex = _find_by_label(self.at.button, "Add Exercise", key="add_ex_btn")
+        self.at.button[idx_add_ex].click().run()
+        btn_idx = _find_by_label(self.at.button, "20.0 kg", key="qw_1_0")
+        self.at.button[btn_idx].click().run()
+        idx_add_set = _find_by_label(self.at.button, "Add Set", key="add_set_1")
+        self.at.button[idx_add_set].click().run()
+
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT weight FROM sets ORDER BY id DESC LIMIT 1;")
+        self.assertAlmostEqual(cur.fetchone()[0], 20.0)
+        conn.close()
+
     def test_equipment_filtering(self) -> None:
         self.at.query_params["tab"] = "library"
         self.at.run()


### PR DESCRIPTION
## Summary
- add customizable quick weight buttons when adding sets
- save quick weights in settings and expose setting in GUI
- track weekly workout streaks in stats service and API
- display weekly streak metrics in the progress summary
- update README with `/stats/weekly_streak` endpoint
- test new functionality
- mark TODO steps 81 and 82 complete

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68860a4d75a88327b8332f9a79e0ce83