### PR TITLE
Add collapsible header on scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -519,3 +519,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Workout consistency analytics must compute the coefficient of variation of days between workouts and be available via `/stats/workout_consistency`.
 - Mobile layout must use a `--vh` CSS variable set via JavaScript in `_configure_page` for reliable viewport height across orientations.
 - Power history analytics must compute average power per day using weight and velocity and be available via `/stats/power_history`.
+- The header must automatically collapse when scrolling down and reappear when scrolling up.

--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,7 @@
 - [x] 71. Add a mini calendar widget showing upcoming planned workouts.
 - [x] 72. Provide quick filter chips for common date ranges in history views.
 - [ ] 73. Implement a unified notification center for alerts and reminders.
-- [ ] 74. Allow users to collapse the header on scroll for more screen space.
+- [x] 74. Allow users to collapse the header on scroll for more screen space.
 - [ ] 75. Create a dedicated analytics landing page with shortcuts to reports.
 - [ ] 76. Add gesture support to close dialogs on mobile by swiping down.
 - [x] 77. Provide an option to auto-open the last viewed workout on startup.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -444,6 +444,18 @@ class GymApp:
                     btn.style.display = window.pageYOffset > window.innerHeight * 0.2 ? 'flex' : 'none';
                 }
             }
+            let lastScrollY = 0;
+            function handleHeaderCollapse() {
+                const header = document.querySelector('.header-wrapper');
+                if (!header) return;
+                const cur = window.pageYOffset;
+                if (cur > lastScrollY && cur > header.offsetHeight) {
+                    header.classList.add('collapsed');
+                } else {
+                    header.classList.remove('collapsed');
+                }
+                lastScrollY = cur;
+            }
             function handleResize() {
                 setMode();
                 setVh();
@@ -457,6 +469,7 @@ class GymApp:
                 window.visualViewport.addEventListener('resize', handleResize);
             }
             window.addEventListener('scroll', toggleScrollTopButton);
+            window.addEventListener('scroll', handleHeaderCollapse);
             window.addEventListener('DOMContentLoaded', handleResize);
             window.addEventListener('load', handleResize);
             handleResize();
@@ -549,6 +562,10 @@ class GymApp:
             }
             .header-wrapper {
                 width: 100%;
+                transition: transform 0.3s ease-in-out;
+            }
+            .header-wrapper.collapsed {
+                transform: translateY(-100%);
             }
             .header-inner {
                 display: flex;

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1021,6 +1021,12 @@ class StreamlitAdditionalGUITest(unittest.TestCase):
         btn_present = any("scroll-top" in m.body for m in self.at.markdown)
         self.assertTrue(btn_present)
 
+    def test_header_collapse_css(self) -> None:
+        css_present = any(
+            "header-wrapper.collapsed" in m.body for m in self.at.markdown
+        )
+        self.assertTrue(css_present)
+
     def test_quick_workout_fab(self) -> None:
         idx = _find_by_label(self.at.button, "➕", key="quick_workout_btn")
         self.at.button[idx].click().run()


### PR DESCRIPTION
## Summary
- implement automatic header collapse on scroll
- add css transitions for header
- mark TODO for header collapse complete
- document new rule in AGENTS.md
- test presence of header collapse styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68861c15b8c8832794dd78e6427e1b89