### PR TITLE
Implement context menu and persist UI state

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -63,7 +63,7 @@
 - [x] 60. Implement optional email export of weekly reports triggered via settings.
 - [x] 61. Consolidate progress charts into a carousel for easier comparison.
 - [x] 62. Add haptic feedback on mobile when logging sets.
-- [ ] 63. Create contextual menus on right click for quick actions on workouts.
+- [x] 63. Create contextual menus on right click for quick actions on workouts.
 - [x] 64. Provide an overview page with widgets summarizing current goals.
 - [x] 65. Add a resizable sidebar for customizing visible metrics.
 - [ ] 66. Support drag and drop to reorder workout templates.

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1075,6 +1075,16 @@ class StreamlitAdditionalGUITest(unittest.TestCase):
         self.at.button[idx].click().run()
         self.assertEqual(self.at.query_params.get("tab"), before)
 
+    def test_workout_context_menu_present(self) -> None:
+        idx_new = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[idx_new].click().run()
+        markup = [m.body for m in self.at.markdown]
+        self.assertTrue(any("ctx-menu" in m for m in markup))
+
 
 class StreamlitTemplateWorkflowTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
- persist expanders by label and restore scroll position
- add context menu JS for workout actions
- ensure workout details have data attributes for context menu targeting
- handle context menu actions via query parameters
- test for context menu markup
- mark TODO item complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886304bf4308327a6cf0a5e3853a489