### PR TITLE
Implement drag-and-drop template reordering

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -927,6 +927,18 @@ class GymAPI:
                 for tid, name, t in templates
             ]
 
+        @self.app.post("/templates/order")
+        def reorder_templates(order: str):
+            try:
+                ids = [int(i) for i in order.split(",") if i]
+            except ValueError:
+                raise HTTPException(status_code=400, detail="invalid ids")
+            try:
+                self.template_workouts.reorder(ids)
+                return {"status": "updated"}
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
         @self.app.put("/templates/{template_id}")
         def update_template(
             template_id: int,


### PR DESCRIPTION
## Summary
- add `position` column to `workout_templates`
- persist template order and expose `/templates/order`
- support template reordering in the Streamlit GUI
- test API reordering functionality and schema migration

## Testing
- `pytest tests/test_api.py::APITestCase::test_template_reordering -q`
- `pytest -q` *(fails: KeyboardInterrupt after all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_688636cb63bc8327b0ceb971b65718d3