### PR TITLE
Preserve scroll on input events

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -66,7 +66,7 @@
 - [x] 63. Create contextual menus on right click for quick actions on workouts.
 - [x] 64. Provide an overview page with widgets summarizing current goals.
 - [x] 65. Add a resizable sidebar for customizing visible metrics.
-- [ ] 66. Support drag and drop to reorder workout templates.
+- [x] 66. Support drag and drop to reorder workout templates.
 - [x] 67. Implement search suggestions as users type in dropdown filters.
 - [x] 68. Offer automatic backup and restore options in settings.
 - [x] 69. Include a timer widget for rest periods between sets.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -543,6 +543,8 @@ class GymApp:
                     navigator.vibrate(50);
                 }
             });
+            document.addEventListener('input', saveScroll, true);
+            document.addEventListener('change', saveScroll, true);
             window.addEventListener('beforeunload', saveScroll);
             </script>
             """

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -34,6 +34,8 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn(".metric-card", content)
         self.assertIn("handleTouchStart", content)
         self.assertIn("scrollY", content)
+        self.assertIn("addEventListener('input', saveScroll", content)
+        self.assertIn("addEventListener('change', saveScroll", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- mark drag-and-drop template reordering complete in TODO
- persist scroll position on input changes in `streamlit_app.py`
- verify new JS listeners in mobile CSS test

## Testing
- `pytest tests/test_streamlit_app.py -k scroll_top_button -q`
- `pytest tests/test_mobile_css.py tests/test_hotkeys.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68863da9f4d4832783374235195abe81