### PR TITLE
Implement mobile dialog swipe close

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,7 @@
 - [ ] 73. Implement a unified notification center for alerts and reminders.
 - [x] 74. Allow users to collapse the header on scroll for more screen space.
 - [ ] 75. Create a dedicated analytics landing page with shortcuts to reports.
-- [ ] 76. Add gesture support to close dialogs on mobile by swiping down.
+- [x] 76. Add gesture support to close dialogs on mobile by swiping down.
 - [x] 77. Provide an option to auto-open the last viewed workout on startup.
 - [ ] 78. Implement lazy loading for long tables to improve performance.
 - [ ] 79. Include a widget to display ongoing challenges and achievements.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1636,6 +1636,15 @@ class GymApp:
                   dlg.setAttribute('tabindex','0');
                   const focusable = dlg.querySelector('input,textarea,select,button');
                   if (focusable) { focusable.focus(); }
+                  let startY = 0;
+                  dlg.addEventListener('touchstart', e => { startY = e.touches[0].clientY; });
+                  dlg.addEventListener('touchend', e => {
+                    const dy = e.changedTouches[0].clientY - startY;
+                    if (dy > 50) {
+                      const close = dlg.querySelector('button[aria-label="Close"]');
+                      if (close) close.click();
+                    }
+                  });
                 }
                 </script>
                 """,

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -36,6 +36,8 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn("scrollY", content)
         self.assertIn("addEventListener('input', saveScroll", content)
         self.assertIn("addEventListener('change', saveScroll", content)
+        self.assertIn("dlg.addEventListener('touchstart'", content)
+        self.assertIn("dlg.addEventListener('touchend'", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- enable closing dialogs by swiping down on mobile
- check for the JS gesture handlers in mobile CSS tests
- mark TODO for swipe gesture complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863f936ba883278b7bc57b5dfe258a