### PR TITLE
Implement persistent UI state tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,7 +76,7 @@
 - [ ] 73. Implement a unified notification center for alerts and reminders.
 - [x] 74. Allow users to collapse the header on scroll for more screen space.
 - [ ] 75. Create a dedicated analytics landing page with shortcuts to reports.
-- [ ] 76. Add gesture support to close dialogs on mobile by swiping down.
+- [x] 76. Add gesture support to close dialogs on mobile by swiping down.
 - [x] 77. Provide an option to auto-open the last viewed workout on startup.
 - [ ] 78. Implement lazy loading for long tables to improve performance.
 - [ ] 79. Include a widget to display ongoing challenges and achievements.
@@ -88,7 +88,7 @@
 - [ ] 85. Add persistent toolbars within expanders for common actions.
 - [ ] 86. Implement fuzzy search for equipment and muscle names.
  - [x] 87. Surface recently used filters at the top of dropdowns.
-- [ ] 88. Provide collapsible filter sections to declutter the interface.
+- [x] 88. Provide collapsible filter sections to declutter the interface.
 - [ ] 89. Add inline editing for workout notes directly in the history list.
 - [ ] 90. Include a progress ring showing completion percentage of planned sets.
 - [ ] 91. Offer bookmarking of favorite analytics views in settings.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1636,6 +1636,15 @@ class GymApp:
                   dlg.setAttribute('tabindex','0');
                   const focusable = dlg.querySelector('input,textarea,select,button');
                   if (focusable) { focusable.focus(); }
+                  let startY = 0;
+                  dlg.addEventListener('touchstart', e => { startY = e.touches[0].clientY; });
+                  dlg.addEventListener('touchend', e => {
+                    const dy = e.changedTouches[0].clientY - startY;
+                    if (dy > 50) {
+                      const close = dlg.querySelector('button[aria-label="Close"]');
+                      if (close) close.click();
+                    }
+                  });
                 }
                 </script>
                 """,
@@ -1854,7 +1863,7 @@ class GymApp:
         if os.environ.get("TEST_MODE") == "1":
             return
         with self._section("Dashboard"):
-            with st.expander("Filters", expanded=True):
+            with st.expander("Filters", expanded=False):
                 if st.session_state.is_mobile:
                     start = st.date_input(
                         "Start",
@@ -3814,7 +3823,7 @@ class GymApp:
         muscles = list(dict.fromkeys(recent_mus + muscles))
         types = ["" ] + self.equipment.fetch_types()
         if st.session_state.is_mobile:
-            with st.expander("Filters", expanded=True):
+            with st.expander("Filters", expanded=False):
                 sel_type = st.multiselect("Type", types, key="lib_eq_type")
                 prefix = st.text_input("Name Contains", key="lib_eq_prefix")
                 mus_filter = st.multiselect("Muscles", muscles, key="lib_eq_mus")
@@ -3843,7 +3852,7 @@ class GymApp:
                         self._show_dialog("Equipment Details", _content)
         else:
             f_col, l_col = st.columns([1, 2], gap="large")
-            with f_col.expander("Filters", expanded=True):
+            with f_col.expander("Filters", expanded=False):
                 sel_type = st.multiselect("Type", types, key="lib_eq_type")
                 prefix = st.text_input("Name Contains", key="lib_eq_prefix")
                 mus_filter = st.multiselect("Muscles", muscles, key="lib_eq_mus")
@@ -3937,7 +3946,7 @@ class GymApp:
         else:
             f_col, l_col = st.columns([1, 2], gap="large")
             with f_col:
-                with st.expander("Filters", expanded=True):
+                with st.expander("Filters", expanded=False):
                     sel_groups = st.multiselect(
                         "Muscle Groups", groups, key="lib_ex_groups"
                     )
@@ -4296,7 +4305,7 @@ class GymApp:
             if st.button("Add Favorite", key="fav_wk_add_btn") and add_choice:
                 self.favorite_workouts_repo.add(int(add_choice))
                 st.rerun()
-        with st.expander("Filters", expanded=True):
+        with st.expander("Filters", expanded=False):
             col1, col2 = st.columns(2)
             with col1:
                 start = st.date_input(
@@ -4398,7 +4407,7 @@ class GymApp:
 
     def _stats_tab(self) -> None:
         st.header("Statistics")
-        with st.expander("Filters", expanded=True):
+        with st.expander("Filters", expanded=False):
             exercises = [""] + self.exercise_names_repo.fetch_all()
             ex_choice = st.selectbox("Exercise", exercises, key="stats_ex")
             col1, col2 = st.columns(2)
@@ -4554,7 +4563,7 @@ class GymApp:
     def _insights_tab(self) -> None:
         st.header("Insights")
         exercises = [""] + self.exercise_names_repo.fetch_all()
-        with st.expander("Filters", expanded=True):
+        with st.expander("Filters", expanded=False):
             ex_choice = st.selectbox("Exercise", exercises, key="insights_ex")
             col1, col2 = st.columns(2)
             with col1:
@@ -4934,7 +4943,7 @@ class GymApp:
     def _risk_tab(self) -> None:
         st.header("Risk & Readiness")
         exercises = [""] + self.exercise_names_repo.fetch_all()
-        with st.expander("Filters", expanded=True):
+        with st.expander("Filters", expanded=False):
             ex_choice = st.selectbox("Exercise for Momentum", exercises, key="risk_ex")
             col1, col2 = st.columns(2)
             with col1:

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -36,6 +36,10 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn("scrollY", content)
         self.assertIn("addEventListener('input', saveScroll", content)
         self.assertIn("addEventListener('change', saveScroll", content)
+        self.assertIn("addEventListener('click', saveScroll", content)
+        self.assertIn("persistExpanders()", content)
+        self.assertIn("dlg.addEventListener('touchstart'", content)
+        self.assertIn("dlg.addEventListener('touchend'", content)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1075,6 +1075,24 @@ class StreamlitAdditionalGUITest(unittest.TestCase):
         self.at.button[idx].click().run()
         self.assertEqual(self.at.query_params.get("tab"), before)
 
+    def test_tab_persistence_on_add_set(self) -> None:
+        before = self.at.query_params.get("tab")
+        idx_new = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[idx_new].click().run()
+        idx_ex = _find_by_label(self.at.selectbox, "Exercise", "Barbell Bench Press")
+        self.at.selectbox[idx_ex].select("Barbell Bench Press").run()
+        idx_eq = _find_by_label(self.at.selectbox, "Equipment Name", "Olympic Barbell")
+        self.at.selectbox[idx_eq].select("Olympic Barbell").run()
+        idx_add_ex = _find_by_label(self.at.button, "Add Exercise", key="add_ex_btn")
+        self.at.button[idx_add_ex].click().run()
+        idx_add_set = _find_by_label(self.at.button, "Add Set", key="add_set_1")
+        self.at.button[idx_add_set].click().run()
+        self.assertEqual(self.at.query_params.get("tab"), before)
+
     def test_workout_context_menu_present(self) -> None:
         idx_new = _find_by_label(
             self.at.button,


### PR DESCRIPTION
## Summary
- mark TODO step 88 complete
- collapse filter sections across the app
- verify expander persistence javascript
- ensure tab stays selected after adding a set

## Testing
- `pytest tests/test_mobile_css.py tests/test_streamlit_app.py tests/test_hotkeys.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68863f936ba883278b7bc57b5dfe258a