### PR TITLE
Implement notification center

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -73,7 +73,7 @@
 - [x] 70. Introduce color coding for workout types across the app.
 - [x] 71. Add a mini calendar widget showing upcoming planned workouts.
 - [x] 72. Provide quick filter chips for common date ranges in history views.
-- [ ] 73. Implement a unified notification center for alerts and reminders.
+- [x] 73. Implement a unified notification center for alerts and reminders.
 - [x] 74. Allow users to collapse the header on scroll for more screen space.
 - [ ] 75. Create a dedicated analytics landing page with shortcuts to reports.
 - [x] 76. Add gesture support to close dialogs on mobile by swiping down.

--- a/rest_api.py
+++ b/rest_api.py
@@ -26,6 +26,7 @@ from db import (
     MLModelRepository,
     MLLogRepository,
     MLModelStatusRepository,
+    NotificationRepository,
     AutoPlannerLogRepository,
     ExercisePrescriptionLogRepository,
     EmailLogRepository,
@@ -88,6 +89,7 @@ class GymAPI:
         self.ml_models = MLModelRepository(db_path)
         self.ml_logs = MLLogRepository(db_path)
         self.ml_status = MLModelStatusRepository(db_path)
+        self.notifications = NotificationRepository(db_path)
         self.autoplan_logs = AutoPlannerLogRepository(db_path)
         self.prescription_logs = ExercisePrescriptionLogRepository(db_path)
         self.email_logs = EmailLogRepository(db_path)
@@ -2273,6 +2275,24 @@ class GymAPI:
         @self.app.get("/reports/email_logs")
         def list_email_logs():
             return self.email_logs.fetch_all_logs()
+
+        @self.app.post("/notifications")
+        def create_notification(message: str = Body(...)):
+            nid = self.notifications.add(message)
+            return {"id": nid}
+
+        @self.app.get("/notifications")
+        def get_notifications(unread_only: bool = False):
+            return self.notifications.fetch_all(unread_only)
+
+        @self.app.put("/notifications/{nid}/read")
+        def mark_notification_read(nid: int):
+            self.notifications.mark_read(nid)
+            return {"status": "read"}
+
+        @self.app.get("/notifications/unread_count")
+        def unread_count():
+            return {"count": self.notifications.unread_count()}
 
 
 api = GymAPI()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3317,3 +3317,22 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(resp.json(), {"status": "restored"})
         resp = self.client.get("/workouts")
         self.assertEqual(len(resp.json()), 1)
+
+    def test_notifications_crud(self) -> None:
+        resp = self.client.post("/notifications", json="Test note")
+        self.assertEqual(resp.status_code, 200)
+        nid = resp.json()["id"]
+
+        resp = self.client.get("/notifications")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()), 1)
+        self.assertFalse(resp.json()[0]["read"])
+
+        resp = self.client.put(f"/notifications/{nid}/read")
+        self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get("/notifications", params={"unread_only": True})
+        self.assertEqual(resp.json(), [])
+
+        resp = self.client.get("/notifications/unread_count")
+        self.assertEqual(resp.json()["count"], 0)

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1028,6 +1028,10 @@ class StreamlitAdditionalGUITest(unittest.TestCase):
         )
         self.assertTrue(css_present)
 
+    def test_notifications_dialog(self) -> None:
+        idx = _find_by_label(self.at.button, "🔔", key="notif_btn")
+        self.assertIsNotNone(self.at.button[idx])
+
     def test_quick_workout_fab(self) -> None:
         idx = _find_by_label(self.at.button, "➕", key="quick_workout_btn")
         self.at.button[idx].click().run()


### PR DESCRIPTION
## Summary
- add notifications table and repository
- add REST API endpoints for notifications
- expose notifications via GUI with a bell icon
- test new API and GUI pieces
- mark TODO step complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68864948d3d08327b0468499910790a5