### PR TITLE
Improve state persistence

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -473,9 +473,10 @@ class GymApp:
             }
             function persistExpanders() {
                 const exps = Array.from(document.querySelectorAll('details'));
-                exps.forEach(exp => {
+                exps.forEach((exp, idx) => {
                     const label = exp.querySelector('summary')?.innerText.trim() || '';
-                    const key = `expander-${label}`;
+                    const key = exp.dataset.expKey || `expander-${label}-${idx}`;
+                    exp.dataset.expKey = key;
                     const saved = sessionStorage.getItem(key);
                     if (saved !== null) exp.open = saved === 'true';
                     exp.addEventListener('toggle', () => {
@@ -505,6 +506,10 @@ class GymApp:
             if (window.visualViewport) {
                 window.visualViewport.addEventListener('resize', handleResize);
             }
+            function restoreScroll() {
+                const y = sessionStorage.getItem('scrollY');
+                if (y) setTimeout(() => window.scrollTo(0, parseInt(y)), 0);
+            }
             window.addEventListener('scroll', () => {
                 toggleScrollTopButton();
                 handleHeaderCollapse();
@@ -512,16 +517,14 @@ class GymApp:
             });
             window.addEventListener('DOMContentLoaded', () => {
                 handleResize();
-                const y = sessionStorage.getItem('scrollY');
-                if (y) window.scrollTo(0, parseInt(y));
+                restoreScroll();
                 persistExpanders();
                 persistTabs();
             });
             document.addEventListener('streamlit:rendered', () => {
                 persistExpanders();
                 persistTabs();
-                const y = sessionStorage.getItem('scrollY');
-                if (y) window.scrollTo(0, parseInt(y));
+                restoreScroll();
             });
             document.addEventListener('click', saveScroll, true);
             handleResize();

--- a/tests/test_mobile_css.py
+++ b/tests/test_mobile_css.py
@@ -38,6 +38,7 @@ class MobileCSSTest(unittest.TestCase):
         self.assertIn("addEventListener('change', saveScroll", content)
         self.assertIn("addEventListener('click', saveScroll", content)
         self.assertIn("persistExpanders()", content)
+        self.assertIn("dataset.expKey", content)
         self.assertIn("dlg.addEventListener('touchstart'", content)
         self.assertIn("dlg.addEventListener('touchend'", content)
 


### PR DESCRIPTION
## Summary
- keep scroll and expander state by giving each expander a unique key and restoring scroll asynchronously
- test that new expander key persists via updated CSS test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865add51108327a6ae393a349dacf1