### PR TITLE
Implement lazy loading and challenges

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -78,8 +78,8 @@
 - [x] 75. Create a dedicated analytics landing page with shortcuts to reports.
 - [x] 76. Add gesture support to close dialogs on mobile by swiping down.
 - [x] 77. Provide an option to auto-open the last viewed workout on startup.
-- [ ] 78. Implement lazy loading for long tables to improve performance.
-- [ ] 79. Include a widget to display ongoing challenges and achievements.
+ - [x] 78. Implement lazy loading for long tables to improve performance.
+ - [x] 79. Include a widget to display ongoing challenges and achievements.
 - [ ] 80. Add undo/redo controls for workout editing actions.
 - [x] 81. Provide customizable quick-add weight values for faster input.
 - [x] 82. Show weekly streak counters on the Progress tab.

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -871,6 +871,11 @@ class StreamlitFullGUITest(unittest.TestCase):
         self.assertEqual(tab.header[0].value, "Gamification Stats")
         self.assertGreaterEqual(len(tab.metric), 2)
 
+    def test_challenges_tab(self) -> None:
+        tab = self._get_tab("Challenges")
+        self.assertEqual(tab.header[0].value, "Challenges")
+        self.assertGreater(len(tab.expander), 0)
+
     def test_tests_tab(self) -> None:
         tab = self._get_tab("Tests")
         self.assertEqual(tab.header[0].value, "Pyramid Test")


### PR DESCRIPTION
## Summary
- add challenge tracking table and repository
- implement challenge CRUD REST API
- create challenges tab in GUI
- support pagination for workout history via API and GUI
- mark TODOs as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886749b7f3c83278477b1f0febc9444