### PR TITLE
Use session state for navigation refresh

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -111,3 +111,7 @@
 - [x] 108. Display estimated calories burned per workout in the summary.
 - [x] 109. Add option to hide completed planned workouts from the calendar.
 - [ ] 110. Support inline graphs of weight progression within the workout log.
+- [ ] 111. Replace explicit st.rerun calls with session state updates to avoid reruns when clicking buttons or entering data.
+  - [ ] 111.1 Introduce _trigger_refresh method toggling a session_state variable.
+  - [ ] 111.2 Apply _trigger_refresh to _refresh and _command_palette.
+  - [ ] 111.3 Review remaining st.rerun usage and replace accordingly.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -317,10 +317,14 @@ class GymApp:
         )
         self._state_init()
 
+    def _trigger_refresh(self) -> None:
+        """Trigger a refresh without calling st.rerun."""
+        st.session_state.refresh_counter = st.session_state.get("refresh_counter", 0) + 1
+
     def _refresh(self) -> None:
         """Reload the application state."""
         if st.button("Refresh"):
-            st.rerun()
+            self._trigger_refresh()
 
     def _command_palette(self) -> None:
         if st.session_state.get("open_palette"):
@@ -328,19 +332,19 @@ class GymApp:
                 if st.button("Workouts"):
                     st.session_state.open_palette = False
                     st.experimental_set_query_params(tab="workouts")
-                    st.rerun()
+                    self._trigger_refresh()
                 if st.button("Library"):
                     st.session_state.open_palette = False
                     st.experimental_set_query_params(tab="library")
-                    st.rerun()
+                    self._trigger_refresh()
                 if st.button("Progress"):
                     st.session_state.open_palette = False
                     st.experimental_set_query_params(tab="progress")
-                    st.rerun()
+                    self._trigger_refresh()
                 if st.button("Settings"):
                     st.session_state.open_palette = False
                     st.experimental_set_query_params(tab="settings")
-                    st.rerun()
+                    self._trigger_refresh()
 
     def _rest_timer(self) -> None:
         start = st.session_state.get("rest_start")


### PR DESCRIPTION
## Summary
- avoid `st.rerun()` when refreshing or using the command palette
- document remaining work in TODO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887154f49288327932c6a9f7e2ab4c4