### PR TITLE
Implement auto-save, sharing, customizable tabs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -103,15 +103,15 @@
 - [x] 100. Enable exporting analytics charts as images from the GUI.
 - [x] 101. Add dynamic breadcrumbs to show navigation context on mobile.
 - [x] 102. Allow pinning important stats to the header for constant visibility.
-- [ ] 103. Provide auto-save of set inputs as they are entered.
+ - [x] 103. Provide auto-save of set inputs as they are entered.
 - [x] 104. Implement color-coded badges for workout intensity levels.
-- [ ] 105. Add quick actions for sharing workouts via social media.
-- [ ] 106. Offer per-user customization for which tabs appear in the nav bar.
+ - [x] 105. Add quick actions for sharing workouts via social media.
+ - [x] 106. Offer per-user customization for which tabs appear in the nav bar.
 - [x] 107. Include example workouts for new users accessible from onboarding.
 - [x] 108. Display estimated calories burned per workout in the summary.
 - [x] 109. Add option to hide completed planned workouts from the calendar.
-- [ ] 110. Support inline graphs of weight progression within the workout log.
-- [ ] 111. Replace explicit st.rerun calls with session state updates to avoid reruns when clicking buttons or entering data.
-  - [ ] 111.1 Introduce _trigger_refresh method toggling a session_state variable.
-  - [ ] 111.2 Apply _trigger_refresh to _refresh and _command_palette.
-  - [ ] 111.3 Review remaining st.rerun usage and replace accordingly.
+ - [x] 110. Support inline graphs of weight progression within the workout log.
+ - [x] 111. Replace explicit st.rerun calls with session state updates to avoid reruns when clicking buttons or entering data.
+  - [x] 111.1 Introduce _trigger_refresh method toggling a session_state variable.
+  - [x] 111.2 Apply _trigger_refresh to _refresh and _command_palette.
+  - [x] 111.3 Review remaining st.rerun usage and replace accordingly.

--- a/rest_api.py
+++ b/rest_api.py
@@ -688,6 +688,16 @@ class GymAPI:
                 },
             )
 
+        @self.app.get("/workouts/{workout_id}/share")
+        def share_workout(workout_id: int):
+            wid, date, *_ = self.workouts.fetch_detail(workout_id)
+            lines = [f"Workout on {date}"]
+            for ex_id, name, _eq, _note in self.exercises.fetch_for_workout(workout_id):
+                sets = self.sets.fetch_for_exercise(ex_id)
+                sstr = ", ".join(f"{r}x{w}" for _sid, r, w, _rp, *_rest in sets)
+                lines.append(f"{name}: {sstr}")
+            return {"text": "\n".join(lines)}
+
         @self.app.get("/workouts/{workout_id}/calories")
         def workout_calories(workout_id: int):
             cal = self.statistics.workout_calories(workout_id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3432,6 +3432,19 @@ class APITestCase(unittest.TestCase):
         resp = self.client.get(f"/workouts/{wid}/calories")
         self.assertGreater(resp.json()["calories"], 0)
 
+    def test_workout_share(self) -> None:
+        wid = self.client.post("/workouts").json()["id"]
+        self.client.post(
+            f"/workouts/{wid}/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 8},
+        )
+        resp = self.client.get(f"/workouts/{wid}/share")
+        self.assertIn("Bench Press", resp.json()["text"])
+
     def test_bookmarks_setting(self) -> None:
         resp = self.client.post("/settings/bookmarks", json="overview,progress")
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- implement session based refresh and auto-save
- add share endpoint and dialog
- allow configuring enabled nav tabs
- update API tests
- update TODO list

## Testing
- `pytest tests/test_api.py::APITestCase::test_workout_share -q`
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_quick_weight_buttons -q`
- `pytest -q` *(fails: AssertionError in quick_weight_buttons)*

------
https://chatgpt.com/codex/tasks/task_e_68871995fa408327a65b0fef1cf7a4c8