### PR TITLE
Fix set title HTML and keep edited set expanded

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2990,14 +2990,20 @@ class GymApp:
                         iclass = "intensity-medium"
                     else:
                         iclass = "intensity-low"
-                    badge = f"<span class='badge {iclass}'>{int(ratio*100)}%</span>"
+                    intensity = int(ratio * 100)
+                    badge = f"<span class='badge {iclass}'>{intensity}%</span>"
                     registered = start_time is not None and end_time is not None
                     row_class = "set-registered" if registered else "set-unregistered"
                     if st.session_state.get("flash_set") == set_id:
                         row_class += " flash"
                         st.session_state.flash_set = None
                     if st.session_state.is_mobile:
-                        with st.expander(f"Set {idx} {badge}"):
+                        exp_label = f"Set {idx} ({intensity}%)"
+                        with st.expander(
+                            exp_label,
+                            expanded=st.session_state.pop(f"open_set_{set_id}", False),
+                        ):
+                            st.markdown(badge, unsafe_allow_html=True)
                             st.markdown(
                                 f"<div class='set-row {row_class}'>",
                                 unsafe_allow_html=True,
@@ -3108,10 +3114,15 @@ class GymApp:
                             )
                             st.markdown("</div>", unsafe_allow_html=True)
                     else:
+                        exp_label = (
+                            f"Set {idx} - {reps}x{weight}{self.weight_unit} RPE {rpe} ({intensity}%)"
+                        )
                         exp = st.expander(
-                            f"Set {idx} - {reps}x{weight}kg RPE {rpe} {badge}", expanded=False
+                            exp_label,
+                            expanded=st.session_state.pop(f"open_set_{set_id}", False),
                         )
                         with exp:
+                            st.markdown(badge, unsafe_allow_html=True)
                             st.markdown(
                                 f"<div class='set-row {row_class}'>",
                                 unsafe_allow_html=True,
@@ -3517,6 +3528,7 @@ class GymApp:
         prev = self.sets.fetch_detail(set_id)
         st.session_state.setdefault("undo_stack", []).append(("update_set", prev))
         st.session_state["redo_stack"] = []
+        st.session_state[f"open_set_{set_id}"] = True
         reps_val = st.session_state.get(f"reps_{set_id}")
         weight_val = st.session_state.get(f"weight_{set_id}")
         rpe_val = st.session_state.get(f"rpe_{set_id}")

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -403,6 +403,35 @@ class StreamlitAppTest(unittest.TestCase):
         html = "".join(m.body for m in self.at.markdown)
         self.assertIn("intensity-high", html)
 
+    def test_set_edit_keeps_open(self) -> None:
+        idx_new = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[idx_new].click().run()
+        idx_ex = _find_by_label(self.at.selectbox, "Exercise", "Barbell Bench Press")
+        self.at.selectbox[idx_ex].select("Barbell Bench Press").run()
+        idx_eq = _find_by_label(self.at.selectbox, "Equipment Name", "Olympic Barbell")
+        self.at.selectbox[idx_eq].select("Olympic Barbell").run()
+        idx_add_ex = _find_by_label(self.at.button, "Add Exercise", key="add_ex_btn")
+        self.at.button[idx_add_ex].click().run()
+        self.at.number_input[0].set_value(5).run()
+        self.at.number_input[1].set_value(100.0).run()
+        idx_add_set = _find_by_label(self.at.button, "Add Set", key="add_set_1")
+        self.at.button[idx_add_set].click().run()
+
+        ex_idx = _find_by_label(
+            self.at.expander, "Barbell Bench Press (Olympic Barbell)"
+        )
+        ex_exp = self.at.expander[ex_idx]
+        set_exp = next(e for e in ex_exp.expander if e.label.startswith("Set 1"))
+        set_exp.number_input[1].set_value(110.0).run()
+
+        ex_exp = self.at.expander[ex_idx]
+        set_exp = next(e for e in ex_exp.expander if e.label.startswith("Set 1"))
+        self.assertTrue(set_exp.proto.expanded)
+
     def test_custom_exercise_and_logs(self) -> None:
         self.at.query_params["tab"] = "settings"
         self.at.run()


### PR DESCRIPTION
## Summary
- display intensity badge inside expander and show text only in title
- keep set expander open after editing
- add regression test for staying open after edit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688739ab68bc83279cf090cb2d8ae8d4