### PR TITLE
Add integration and GUI tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-1. Add integration tests for API endpoints to ensure proper database access.
+[complete] 1. Add integration tests for API endpoints to ensure proper database access.
 2. Add tests for GUI components described in streamlittestinghowto.md.
 3. Refactor rest_api.py to group routes by resource using APIRouter.
 4. Document API endpoints with OpenAPI descriptions.

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,60 @@
+import os
+import sqlite3
+import unittest
+from fastapi.testclient import TestClient
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from rest_api import GymAPI
+
+
+class APIIntegrationDBTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db_path = "test_integration.db"
+        self.yaml_path = "test_integration.yaml"
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        if os.path.exists(self.yaml_path):
+            os.remove(self.yaml_path)
+        self.api = GymAPI(db_path=self.db_path, yaml_path=self.yaml_path)
+        self.client = TestClient(self.api.app)
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        if os.path.exists(self.yaml_path):
+            os.remove(self.yaml_path)
+
+    def _count_rows(self, table: str) -> int:
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute(f"SELECT COUNT(*) FROM {table};")
+        count = cur.fetchone()[0]
+        conn.close()
+        return count
+
+    def test_workout_creation_persists(self) -> None:
+        resp = self.client.post("/workouts")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"id": 1})
+        self.assertEqual(self._count_rows("workouts"), 1)
+
+    def test_add_exercise_and_set(self) -> None:
+        self.client.post("/workouts")
+        resp = self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench", "equipment": "Olympic Barbell"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"id": 1})
+        self.assertEqual(self._count_rows("exercises"), 1)
+        resp = self.client.post(
+            "/exercises/1/sets", params={"reps": 5, "weight": 100.0, "rpe": 8}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"id": 1})
+        self.assertEqual(self._count_rows("sets"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -821,6 +821,25 @@ class StreamlitAppTest(unittest.TestCase):
         shutil.rmtree(remote_dir)
         shutil.rmtree(repo_dir)
 
+    def test_compact_mode_toggle(self) -> None:
+        self.at.query_params["tab"] = "settings"
+        self.at.run()
+        settings_tab = self._get_tab("Settings")
+        idx = _find_by_label(settings_tab.checkbox, "Compact Mode")
+        current = settings_tab.checkbox[idx].value
+        if current:
+            settings_tab.checkbox[idx].uncheck().run()
+        else:
+            settings_tab.checkbox[idx].check().run()
+        save_idx = _find_by_label(settings_tab.button, "Save General Settings")
+        settings_tab.button[save_idx].click().run()
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT value FROM settings WHERE key = 'compact_mode';")
+        val = cur.fetchone()[0]
+        conn.close()
+        self.assertEqual(bool(int(val)), not current)
+
 
 class StreamlitFullGUITest(unittest.TestCase):
     def setUp(self) -> None:
@@ -1350,6 +1369,25 @@ class StreamlitHeartRateGUITest(unittest.TestCase):
         cur.execute("SELECT heart_rate FROM heart_rate_logs WHERE workout_id = 1;")
         self.assertEqual(cur.fetchone()[0], 120)
         conn.close()
+    def test_compact_mode_toggle(self) -> None:
+        self.at.query_params["tab"] = "settings"
+        self.at.run()
+        settings_tab = self._get_tab("Settings")
+        idx = _find_by_label(settings_tab.checkbox, "Compact Mode")
+        current = settings_tab.checkbox[idx].value
+        if current:
+            settings_tab.checkbox[idx].uncheck().run()
+        else:
+            settings_tab.checkbox[idx].check().run()
+        save_idx = _find_by_label(settings_tab.button, "Save General Settings")
+        settings_tab.button[save_idx].click().run()
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT value FROM settings WHERE key = 'compact_mode';")
+        val = cur.fetchone()[0]
+        conn.close()
+        self.assertEqual(bool(int(val)), not current)
+
 
 
 @unittest.skip("Unstable in CI")


### PR DESCRIPTION
## Summary
- add integration tests verifying DB persistence
- cover compact mode toggle in GUI tests
- mark TODO step for integration tests as complete

## Testing
- `pytest tests/test_api_integration.py -q`
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_compact_mode_toggle -q`
- `pytest -q` (interrupted after completion)

------
https://chatgpt.com/codex/tasks/task_e_688744832dfc8327975441bd6269ce7c