### PR TITLE
Implement default equipment mapping

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,4 +1,1 @@
-- tests/test_streamlit_app.py::StreamlitAllInteractionsTest::test_all_visible_widgets
 - tests/test_streamlit_app.py::StreamlitAppTest::test_quick_weight_buttons
-- tests/test_streamlit_app.py::StreamlitAdditionalGUITest::test_plan_progress_ring
-- tests/test_streamlit_app.py::StreamlitHeartRateGUITest::test_compact_mode_toggle

--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@
 31. Implement progressive web app features for offline use.
 [complete] 32. Add endpoint to download body_weight_logs as CSV.
 [complete] 33. Provide monthly summary emails via Cron or Celery.
-34. Add user-defined default equipment per exercise.
+[complete] 34. Add user-defined default equipment per exercise.
 35. Implement privacy settings for shared workouts.
 36. Add voice command support in the GUI.
 37. Add voice feedback for timer events using STT.

--- a/planner_service.py
+++ b/planner_service.py
@@ -124,9 +124,17 @@ class PlannerService:
         self, workout_id: int, name: str | None = None
     ) -> int:
         """Create a template from an existing workout."""
-        _wid, _date, _s, _e, t_type, _notes, _loc, _rating = self.workouts.fetch_detail(
-            workout_id
-        )
+        (
+            _wid,
+            _date,
+            _s,
+            _e,
+            t_type,
+            _notes,
+            _loc,
+            _rating,
+            *_,
+        ) = self.workouts.fetch_detail(workout_id)
         if name is None:
             name = f"Workout {workout_id}"
         template_id = self.templates.create(name, t_type)

--- a/stats_service.py
+++ b/stats_service.py
@@ -1355,7 +1355,7 @@ class StatisticsService:
             return []
         workouts = self.workouts.fetch_all_workouts(start_date, end_date)
         stats: Dict[str, Dict[str, float | int]] = {}
-        for wid, _date, _s, _e, t_type, _notes, _rating in workouts:
+        for wid, _date, _s, _e, t_type, _notes, _rating, *_ in workouts:
             summary = self.sets.workout_summary(wid)
             entry = stats.setdefault(t_type, {"workouts": 0, "volume": 0.0, "sets": 0})
             entry["workouts"] += 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2994,6 +2994,28 @@ class APITestCase(unittest.TestCase):
         list_resp = self.client.get("/favorites/workouts")
         self.assertNotIn(1, list_resp.json())
 
+    def test_default_equipment(self) -> None:
+        resp = self.client.post(
+            "/default_equipment",
+            params={"exercise_name": "Bench Press", "equipment_name": "Olympic Barbell"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "set"})
+
+        resp = self.client.get("/default_equipment/Bench Press")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"equipment_name": "Olympic Barbell"})
+
+        lst = self.client.get("/default_equipment").json()
+        self.assertIn({"exercise_name": "Bench Press", "equipment_name": "Olympic Barbell"}, lst)
+
+        resp = self.client.delete("/default_equipment/Bench Press")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "deleted"})
+
+        resp = self.client.get("/default_equipment/Bench Press")
+        self.assertIsNone(resp.json()["equipment_name"])
+
     def test_copy_workout_to_template(self) -> None:
         self.client.post("/workouts")
         self.client.post(


### PR DESCRIPTION
## Summary
- add default_equipment table and repository
- expose REST endpoints for managing default equipment
- allow planner_service to unpack extended workout detail
- update statistics and history endpoints to handle extra columns
- record remaining failing GUI test
- mark TODO for default equipment as complete

## Testing
- `pytest tests/test_api.py::APITestCase::test_default_equipment -q`
- `pytest tests/test_api.py::APITestCase::test_training_type_summary_endpoint tests/test_api.py::APITestCase::test_workout_history_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b2e24c6083279abea4effe79e33f