### PR TITLE
Implement SQLite view caching for weight stats

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,1 +1,5 @@
 - tests/test_streamlit_app.py::StreamlitAppTest::test_quick_weight_buttons
+- tests/test_streamlit_app.py::StreamlitAdditionalGUITest::test_plan_progress_ring
+- tests/test_streamlit_app.py::StreamlitAdditionalGUITest::test_workout_context_menu_present
+- tests/test_streamlit_app.py::StreamlitHeartRateGUITest::test_compact_mode_toggle
+- tests/test_streamlit_app.py::RecommendationIntegrationTest::test_csv_uploader_present

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,7 @@
 [complete] 21. Add unit tests for ml_service models.
 [complete] 22. Provide interactive charts for power and velocity histories.
 [complete] 23. Add endpoint for exercise alias removal.
-24. Implement caching for statistics queries using SQLite views.
+[complete] 24. Implement caching for statistics queries using SQLite views.
 [complete] 25. Add Jenkinsfile for automated build.
 [complete] 26. Add color-blind friendly theme options.
 [complete] 27. Implement rate limiting on REST API endpoints.

--- a/rest_api.py
+++ b/rest_api.py
@@ -46,6 +46,7 @@ from db import (
     TagRepository,
     GoalRepository,
     ChallengeRepository,
+    StatsCacheRepository,
 )
 from planner_service import PlannerService
 from recommendation_service import RecommendationService
@@ -167,6 +168,7 @@ class GymAPI:
         self.body_weights = BodyWeightRepository(db_path)
         self.wellness = WellnessRepository(db_path)
         self.heart_rates = HeartRateRepository(db_path)
+        self.stats_cache = StatsCacheRepository(db_path)
         self.goals = GoalRepository(db_path)
         self.challenges = ChallengeRepository(db_path)
         self.watchers: list[WebSocket] = []
@@ -246,6 +248,7 @@ class GymAPI:
             self.workouts,
             self.heart_rates,
             self.goals,
+            cache_repo=self.stats_cache,
         )
         self.app = FastAPI(
             title="Gym API",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -50,6 +50,7 @@ from db import (
     GoalRepository,
     NotificationRepository,
     ChallengeRepository,
+    StatsCacheRepository,
 )
 from planner_service import PlannerService
 from recommendation_service import RecommendationService
@@ -262,6 +263,7 @@ class GymApp:
         self.body_weights_repo = BodyWeightRepository(db_path)
         self.wellness_repo = WellnessRepository(db_path)
         self.heart_rates = HeartRateRepository(db_path)
+        self.stats_cache_repo = StatsCacheRepository(db_path)
         self.gamification = GamificationService(
             self.game_repo,
             self.exercises,
@@ -327,6 +329,7 @@ class GymApp:
             self.exercise_catalog,
             self.workouts,
             self.heart_rates,
+            cache_repo=self.stats_cache_repo,
         )
         self._state_init()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2537,6 +2537,9 @@ class APITestCase(unittest.TestCase):
         self.assertAlmostEqual(stats["avg"], 81.0, places=2)
         self.assertEqual(stats["min"], 80.0)
         self.assertEqual(stats["max"], 82.0)
+        cached = self.api.stats_cache.fetch_weight_stats(d1, d2, "kg")
+        self.assertIsNotNone(cached)
+        self.assertAlmostEqual(cached["avg"], 81.0, places=2)
 
         resp = self.client.get(
             "/stats/weight_stats",
@@ -2547,6 +2550,9 @@ class APITestCase(unittest.TestCase):
 
         resp = self.client.post("/stats/cache/clear")
         self.assertEqual(resp.json(), {"status": "cleared"})
+        self.assertIsNone(
+            self.api.stats_cache.fetch_weight_stats(d1, d2, "kg")
+        )
 
     def test_current_body_weight_latest_log(self) -> None:
         d1 = "2023-01-01"


### PR DESCRIPTION
## Summary
- implement database views for cached stats
- add `StatsCacheRepository` for managing cached statistics
- hook caching into `StatisticsService` and API/GUI constructors
- mark caching task complete in TODO
- log failing GUI tests in FAILEDTESTS.md
- test caching via updated API test

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Streamlit GUI tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887bb45d45483279919af2b3a3dc6b5