### PR TITLE
Add goal-based planner

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 [complete] 6. Implement pagination on workout history API.
 [complete] 7. Create CLI to export workouts to CSV and JSON.
 [complete] 8. Add scheduling for regular email reports.
-9. Improve planner_service with goal-based plan suggestions.
+[complete] 9. Improve planner_service with goal-based plan suggestions.
 [complete] 10. Validate YAML settings via schema on startup.
 [complete] 11. Add backup/restore commands for the SQLite database.
 [complete] 12. Add continuous integration workflow running tests on push.

--- a/db.py
+++ b/db.py
@@ -3443,6 +3443,31 @@ class GoalRepository(BaseRepository):
             )
         return result
 
+    def fetch_all_active(self, today: str | None = None) -> list[dict[str, object]]:
+        """Return all currently active goals ordered by target date."""
+        current = today or datetime.date.today().isoformat()
+        rows = super().fetch_all(
+            "SELECT id, exercise_name, name, target_value, unit, start_date, target_date, achieved "
+            "FROM goals WHERE achieved = 0 AND start_date <= ? AND target_date >= ? "
+            "ORDER BY target_date;",
+            (current, current),
+        )
+        result = []
+        for r in rows:
+            result.append(
+                {
+                    "id": r[0],
+                    "exercise_name": r[1],
+                    "name": r[2],
+                    "target_value": float(r[3]),
+                    "unit": r[4],
+                    "start_date": r[5],
+                    "target_date": r[6],
+                    "achieved": bool(r[7]),
+                }
+            )
+        return result
+
 
 class AutoPlannerLogRepository(BaseRepository):
     """Repository for autoplanner run logs."""

--- a/rest_api.py
+++ b/rest_api.py
@@ -250,6 +250,7 @@ class GymAPI:
             self.template_sets,
             recommender=self.recommender,
             log_repo=self.autoplan_logs,
+            goal_repo=self.goals,
         )
         self.statistics = StatisticsService(
             self.sets,
@@ -1271,6 +1272,14 @@ class GymAPI:
                     pairs.append((it, None))
             try:
                 pid = self.planner.create_ai_plan(date, pairs, training_type)
+                return {"id": pid}
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
+        @self.app.post("/planned_workouts/goal_plan")
+        def goal_plan(date: str):
+            try:
+                pid = self.planner.create_goal_plan(date)
                 return {"id": pid}
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -313,6 +313,7 @@ class GymApp:
             self.template_sets,
             recommender=self.recommender,
             log_repo=self.autoplan_logs,
+            goal_repo=self.goals_repo,
         )
         self.stats = StatisticsService(
             self.sets,
@@ -2568,6 +2569,17 @@ class GymApp:
                         st.warning(str(e))
                 else:
                     st.warning("Select exercises")
+        with st.expander("Goal Planner", expanded=False):
+            gp_date = st.date_input(
+                "Plan Date", datetime.date.today(), key="goal_plan_date"
+            )
+            if st.button("Generate Goal Plan", key="goal_plan_btn"):
+                try:
+                    pid = self.planner.create_goal_plan(gp_date.isoformat())
+                    st.session_state.selected_planned_workout = pid
+                    st.success("Plan created")
+                except ValueError as e:
+                    st.warning(str(e))
         if st.query_params.get("tab") == "workouts":
             with st.expander("Templates", expanded=False):
                 self._template_section()


### PR DESCRIPTION
## Summary
- fetch active goals helper in GoalRepository
- use goals in PlannerService to generate new plans
- add REST endpoint and GUI controls for goal planner
- add tests for goal planner API and GUI
- mark TODO step as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68885d2f813883278b692b96e26d8326