### PR TITLE
Implement per-muscle progress analytics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 [complete] 10. Validate YAML settings via schema on startup.
 [complete] 11. Add backup/restore commands for the SQLite database.
 [complete] 12. Add continuous integration workflow running tests on push.
-13. Expand statistics to include per-muscle progress charts.
+[complete] 13. Expand statistics to include per-muscle progress charts.
 [complete] 14. Add endpoint for editing wellness logs.
 [complete] 15. Create responsive mobile layout tests for each GUI tab.
 [complete] 16. Include weight unit conversion support in stats_service.

--- a/rest_api.py
+++ b/rest_api.py
@@ -1748,6 +1748,18 @@ class GymAPI:
                 end_date,
             )
 
+        @self.app.get("/stats/muscle_progression")
+        def stats_muscle_progression(
+            muscle: str,
+            start_date: str = None,
+            end_date: str = None,
+        ):
+            return self.statistics.muscle_progression(
+                muscle,
+                start_date,
+                end_date,
+            )
+
         @self.app.get("/stats/daily_volume")
         def stats_daily_volume(
             start_date: str = None,


### PR DESCRIPTION
## Summary
- mark TODO for per-muscle progress charts complete
- add `muscle_progression` method in `StatisticsService`
- expose `/stats/muscle_progression` endpoint
- test per-muscle progression analytics

## Testing
- `pytest tests/test_api.py::APITestCase::test_muscle_progression_endpoint -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887aef95748327b2ce45885222b7a9