### PR TITLE
Implement configurable RPE scale

### DIFF
--- a/rest_api.py
+++ b/rest_api.py
@@ -145,16 +145,16 @@ class GymAPI:
         rate_window: int = 60,
     ) -> None:
         self.db_path = db_path
+        self.settings = SettingsRepository(db_path, yaml_path)
         self.workouts = WorkoutRepository(db_path)
         self.exercises = ExerciseRepository(db_path)
-        self.sets = SetRepository(db_path)
+        self.sets = SetRepository(db_path, self.settings)
         self.planned_workouts = PlannedWorkoutRepository(db_path)
         self.planned_exercises = PlannedExerciseRepository(db_path)
-        self.planned_sets = PlannedSetRepository(db_path)
+        self.planned_sets = PlannedSetRepository(db_path, self.settings)
         self.template_workouts = TemplateWorkoutRepository(db_path)
         self.template_exercises = TemplateExerciseRepository(db_path)
         self.template_sets = TemplateSetRepository(db_path)
-        self.settings = SettingsRepository(db_path, yaml_path)
         self.equipment_types = EquipmentTypeRepository(db_path, self.settings)
         self.equipment = EquipmentRepository(
             db_path, self.settings, self.equipment_types
@@ -2719,6 +2719,7 @@ class GymAPI:
             weekly_report_email: str = None,
             experimental_models_enabled: bool = None,
             hide_completed_plans: bool = None,
+            rpe_scale: int = None,
         ):
             if body_weight is not None:
                 self.settings.set_float("body_weight", body_weight)
@@ -2730,6 +2731,8 @@ class GymAPI:
                 self.settings.set_text("theme", theme)
             if color_theme is not None:
                 self.settings.set_text("color_theme", color_theme)
+            if rpe_scale is not None:
+                self.settings.set_int("rpe_scale", rpe_scale)
             if ml_all_enabled is not None:
                 self.settings.set_bool("ml_all_enabled", ml_all_enabled)
             if ml_training_enabled is not None:

--- a/settings_schema.py
+++ b/settings_schema.py
@@ -4,6 +4,7 @@ class SettingsSchema(BaseModel):
     theme: str = "light"
     weight_unit: str = "kg"
     time_format: str = "24h"
+    rpe_scale: int = 10
 
 def validate_settings(data: dict) -> None:
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -408,6 +408,25 @@ class APITestCase(unittest.TestCase):
         )
         self.assertIn("Barbell Bench Press", resp.json())
 
+    def test_rpe_scale_setting(self) -> None:
+        resp = self.client.post("/settings/general", params={"rpe_scale": 5})
+        self.assertEqual(resp.status_code, 200)
+        self.client.post("/workouts")
+        self.client.post(
+            "/workouts/1/exercises",
+            params={"name": "Bench Press", "equipment": "Olympic Barbell"},
+        )
+        ok = self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 5},
+        )
+        self.assertEqual(ok.status_code, 200)
+        bad = self.client.post(
+            "/exercises/1/sets",
+            params={"reps": 5, "weight": 100.0, "rpe": 6},
+        )
+        self.assertEqual(bad.status_code, 400)
+
     def test_plan_workflow(self) -> None:
         plan_date = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
 


### PR DESCRIPTION
## Summary
- add `rpe_scale` to settings schema and defaults
- enforce RPE limits using settings in set repositories
- expose `rpe_scale` via REST and Streamlit UI
- adjust RPE inputs in the UI to respect configured scale
- fix calendar tab unpacking error
- test RPE scale setting

## Testing
- `pytest tests/test_api.py::APITestCase::test_rpe_scale_setting -q`

------
https://chatgpt.com/codex/tasks/task_e_688881f292048327bf3075483fe77c7f