### PR TITLE
Remove jump to section and allow past workout dates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,3 +523,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Power history analytics must compute average power per day using weight and velocity and be available via `/stats/power_history`.
 - The header must automatically collapse when scrolling down and reappear when scrolling up.
 - Multiuser features are prohibited. The application must remain single-user and any existing multiuser functionality should be removed.
+- The "Jump to Section" dropdown has been removed from the UI and must not be reintroduced.

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,9 @@
 [complete] 16. Include weight unit conversion support in stats_service.
 [complete] 17. Add dark/light theme switch stored in settings.
 [removed] 18. Remove two-factor authentication and login features (multiuser removed).
-19. Add localization framework for multi-language UI.
+[complete] 19. Add localization framework for multi-language UI.
+19b. Integrate translations for UI labels.
+19c. Add language selector in settings.
 20. Refactor database layer to async for FastAPI performance.
 [complete] 21. Add unit tests for ml_service models.
 [complete] 22. Provide interactive charts for power and velocity histories.

--- a/db.py
+++ b/db.py
@@ -777,6 +777,7 @@ class Database:
             "pinned_stats": "",
             "hide_completed_plans": "0",
             "rpe_scale": "10",
+            "language": "en",
         }
         with self._connection() as conn:
             for key, value in defaults.items():

--- a/localization.py
+++ b/localization.py
@@ -1,0 +1,12 @@
+class Translator:
+    def __init__(self) -> None:
+        self.language = "en"
+        self.translations = {"en": {}}
+
+    def set_language(self, lang: str) -> None:
+        self.language = lang
+
+    def gettext(self, key: str) -> str:
+        return self.translations.get(self.language, {}).get(key, key)
+
+translator = Translator()

--- a/settings_schema.py
+++ b/settings_schema.py
@@ -5,6 +5,7 @@ class SettingsSchema(BaseModel):
     weight_unit: str = "kg"
     time_format: str = "24h"
     rpe_scale: int = 10
+    language: str = "en"
 
 def validate_settings(data: dict) -> None:
     try:

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -177,6 +177,23 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertIsNotNone(end_time)
         conn.close()
 
+    def test_create_workout_past_date(self) -> None:
+        past = datetime.date.today() - datetime.timedelta(days=2)
+        idx_date = _find_by_label(self.at.date_input, "Date", key="new_workout_date")
+        self.at.date_input[idx_date].set_value(past).run()
+        idx_new = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[idx_new].click().run()
+
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT date FROM workouts;")
+        self.assertEqual(cur.fetchone()[0], past.isoformat())
+        conn.close()
+
     def test_finish_summary_banner(self) -> None:
         idx_new = _find_by_label(
             self.at.button,
@@ -235,12 +252,6 @@ class StreamlitAppTest(unittest.TestCase):
         ex_exp = self.at.expander[exp_idx]
         options = ex_exp.selectbox[0].options
         self.assertEqual(len(options), 1)
-
-    def test_jump_to_section_selectbox(self) -> None:
-        idx = _find_by_label(self.at.selectbox, "Jump to Section", key="log_jump")
-        options = self.at.selectbox[idx].options
-        self.assertIn("Workouts", options)
-
     def test_plan_to_workout(self) -> None:
         idx_date = _find_by_label(self.at.date_input, "Plan Date", key="plan_date")
         self.at.date_input[idx_date].set_value("2024-01-02").run()


### PR DESCRIPTION
## Summary
- remove unused "Jump to Section" select box
- add localization framework skeleton
- support custom language setting
- allow selecting date when creating a new workout
- update GUI test for past date creation
- document change in AGENTS.md and TODO.md

## Testing
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_create_workout_past_date -q`

------
https://chatgpt.com/codex/tasks/task_e_688890643ccc8327815dcfcc82516f03