### PR TITLE
Add font size setting and clear history filters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -155,7 +155,7 @@
 [complete] 148. Inline editing of tags.
 149. Simple mode toggle hiding advanced fields.
 [complete] 150. Color-code sets by intensity level.
-151. Adjustable font size slider in settings.
+[complete] 151. Adjustable font size slider in settings.
 152. Import images using mobile share menu.
 153. Quick-add rest notes after each set.
 154. Contextual help tips on each page.
@@ -204,5 +204,5 @@
 197. Preview thumbnails for uploaded images.
 198. Keyboard shortcut to toggle dark mode.
 199. Flexible grid layout toggle.
-200. "Clear filters" button in history tab.
+[complete] 200. "Clear filters" button in history tab.
 201. Remove all multiuser features from the code base.

--- a/settings_schema.py
+++ b/settings_schema.py
@@ -6,6 +6,7 @@ class SettingsSchema(BaseModel):
     time_format: str = "24h"
     rpe_scale: int = 10
     language: str = "en"
+    font_size: int = 16
     collapse_header: bool = True
 
 def validate_settings(data: dict) -> None:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -222,6 +222,7 @@ class GymApp:
         self.add_set_key = self.settings_repo.get_text("hotkey_add_set", "a")
         self.tab_keys = self.settings_repo.get_text("hotkey_tab_keys", "1,2,3,4")
         self.sidebar_width = self.settings_repo.get_float("sidebar_width", 18.0)
+        self.font_size = self.settings_repo.get_float("font_size", 16.0)
         self.rpe_scale = self.settings_repo.get_int("rpe_scale", 10)
         self.training_options = sorted(
             [
@@ -668,7 +669,7 @@ class GymApp:
                 --header-bg: #ffffff;
                 --border-color: #cccccc;
                 --safe-bottom: 0px;
-                --base-font-size: 16px;
+                --base-font-size: SIZEpx;
                 --sidebar-width: WIDTHrem;
             }}
             html {
@@ -1456,14 +1457,11 @@ class GymApp:
             }
             </style>
             """
+        size = max(self.font_size, 18.0) if self.large_font else self.font_size
         st.markdown(
-            css.replace("WIDTH", str(self.sidebar_width)), unsafe_allow_html=True
+            css.replace("WIDTH", str(self.sidebar_width)).replace("SIZE", str(int(size))),
+            unsafe_allow_html=True,
         )
-        if self.large_font:
-            st.markdown(
-                "<style>:root{--base-font-size:18px;}</style>",
-                unsafe_allow_html=True,
-            )
         if self.compact_mode and not st.session_state.get("is_mobile", False):
             st.markdown(
                 """
@@ -4933,6 +4931,10 @@ class GymApp:
             )
             tag_names = [n for _, n in self.tags_repo.fetch_all()]
             sel_tags = st.multiselect("Tags", tag_names, key="hist_tags")
+            if st.button("Clear Filters", key="hist_clear"):
+                st.session_state.hist_type = ""
+                st.session_state.hist_tags = []
+                self._trigger_refresh()
             start_str = start.isoformat()
             end_str = end.isoformat()
         load_more = st.session_state.pop("load_more_hist", False)
@@ -6191,6 +6193,12 @@ class GymApp:
                     "Large Font Mode",
                     value=self.large_font,
                 )
+                font_size_in = st.slider(
+                    "Font Size (px)",
+                    12,
+                    24,
+                    value=int(self.font_size),
+                )
                 side_nav_opt = st.checkbox(
                     "Enable Side Navigation",
                     value=self.side_nav,
@@ -6389,6 +6397,8 @@ class GymApp:
                 self.compact_mode = compact
                 self.settings_repo.set_bool("large_font_mode", large_font)
                 self.large_font = large_font
+                self.settings_repo.set_float("font_size", float(font_size_in))
+                self.font_size = float(font_size_in)
                 self.settings_repo.set_bool("side_nav", side_nav_opt)
                 self.side_nav = side_nav_opt
                 self.settings_repo.set_bool("show_onboarding", show_onboard_opt)

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -857,6 +857,22 @@ class StreamlitAppTest(unittest.TestCase):
         conn.close()
         self.assertEqual(bool(int(val)), not current)
 
+    def test_font_size_slider(self) -> None:
+        self.at.query_params["tab"] = "settings"
+        self.at.run()
+        settings_tab = self._get_tab("Settings")
+        idx = _find_by_label(settings_tab.slider, "Font Size (px)")
+        current = settings_tab.slider[idx].value
+        settings_tab.slider[idx].set_value(current + 1).run()
+        save_idx = _find_by_label(settings_tab.button, "Save General Settings")
+        settings_tab.button[save_idx].click().run()
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT value FROM settings WHERE key = 'font_size';")
+        val = cur.fetchone()[0]
+        conn.close()
+        self.assertEqual(int(float(val)), int(current) + 1)
+
     def test_language_selector(self) -> None:
         self.at.query_params["tab"] = "settings"
         self.at.run()
@@ -918,6 +934,7 @@ class StreamlitFullGUITest(unittest.TestCase):
         self.assertIn("Last 7d", buttons)
         self.assertIn("Last 30d", buttons)
         self.assertIn("Last 90d", buttons)
+        self.assertIn("Clear Filters", buttons)
 
     def test_dashboard_tab(self) -> None:
         tab = self._get_tab("Dashboard")


### PR DESCRIPTION
## Summary
- add adjustable font size in settings
- implement Clear Filters button in history tab
- update schema and tests
- mark TODO items complete

## Testing
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_compact_mode_toggle tests/test_streamlit_app.py::StreamlitAppTest::test_font_size_slider tests/test_streamlit_app.py::StreamlitFullGUITest::test_history_tab -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a5f2994c832796f56e699dceb566