### PR TITLE
Add status badges for workouts and sets

### DIFF
--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -420,6 +420,44 @@ class StreamlitAppTest(unittest.TestCase):
         html = "".join(m.body for m in self.at.markdown)
         self.assertIn("intensity-high", html)
 
+    def test_status_badges(self) -> None:
+        self.at.query_params["tab"] = "workouts"
+        self.at.run()
+        idx_new = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[idx_new].click().run()
+        html = "".join(m.body for m in self.at.markdown)
+        self.assertIn("status-idle", html)
+        start_idx = _find_by_label(self.at.button, "Start Workout")
+        self.at.button[start_idx].click().run()
+        html = "".join(m.body for m in self.at.markdown)
+        self.assertIn("status-running", html)
+        idx_ex = _find_by_label(self.at.selectbox, "Exercise", "Barbell Bench Press")
+        self.at.selectbox[idx_ex].select("Barbell Bench Press").run()
+        idx_eq = _find_by_label(self.at.selectbox, "Equipment Name", "Olympic Barbell")
+        self.at.selectbox[idx_eq].select("Olympic Barbell").run()
+        idx_add_ex = _find_by_label(self.at.button, "Add Exercise", key="add_ex_btn")
+        self.at.button[idx_add_ex].click().run()
+        self.at.number_input[0].set_value(5).run()
+        self.at.number_input[1].set_value(100.0).run()
+        idx_add_set = _find_by_label(self.at.button, "Add Set", key="add_set_1")
+        self.at.button[idx_add_set].click().run()
+        start_set_idx = _find_by_label(self.at.button, "Start", key="start_set_1")
+        self.at.button[start_set_idx].click().run()
+        html = "".join(m.body for m in self.at.markdown)
+        self.assertIn("status-running", html)
+        finish_set_idx = _find_by_label(self.at.button, "Finish", key="finish_set_1")
+        self.at.button[finish_set_idx].click().run()
+        html = "".join(m.body for m in self.at.markdown)
+        self.assertIn("status-finished", html)
+        finish_idx = _find_by_label(self.at.button, "Finish Workout")
+        self.at.button[finish_idx].click().run()
+        html = "".join(m.body for m in self.at.markdown)
+        self.assertIn("status-finished", html)
+
     def test_set_edit_keeps_open(self) -> None:
         idx_new = _find_by_label(
             self.at.button,


### PR DESCRIPTION
## Summary
- show workout status badges (idle, running, finished)
- display set status badges similarly
- style new badges in CSS
- test status badge rendering in Streamlit

## Testing
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_status_badges -q -s`

------
https://chatgpt.com/codex/tasks/task_e_6888b58325d88327bfedc2ae8c7a1064