### PR TITLE
Add async workout repository

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,9 +24,12 @@
 [complete] 19b. Integrate translations for UI labels.
 [complete] 19c. Add language selector in settings.
 [complete] 20a. Create asynchronous repository layer using aiosqlite.
-20b. Convert existing repositories to use AsyncBaseRepository.
-20c. Update REST API endpoints to use async repositories.
-20d. Update tests for async database operations.
+20b1. Convert WorkoutRepository to AsyncWorkoutRepository. [complete]
+20b2. Convert remaining repositories to async versions.
+20c1. Update REST API workouts endpoints to async. [pending]
+20c2. Update remaining endpoints to async.
+20d1. Add tests for AsyncWorkoutRepository. [complete]
+20d2. Update remaining tests for async operations.
 [complete] 21. Add unit tests for ml_service models.
 [complete] 22. Provide interactive charts for power and velocity histories.
 [complete] 23. Add endpoint for exercise alias removal.

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -4,7 +4,7 @@ import asyncio
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from db import AsyncBaseRepository
+from db import AsyncBaseRepository, AsyncWorkoutRepository
 
 class NumberRepository(AsyncBaseRepository):
     async def init_db(self) -> None:
@@ -25,3 +25,15 @@ async def test_async_repository(tmp_path):
     await repo.init_db()
     await repo.add(5)
     assert await repo.all() == [5]
+
+
+@pytest.mark.asyncio
+async def test_async_workout_repo(tmp_path):
+    db_file = str(tmp_path / "workout.db")
+    repo = AsyncWorkoutRepository(db_file)
+    wid = await repo.create("2024-01-01")
+    assert wid == 1
+    rows = await repo.fetch_all_workouts()
+    assert rows[0][0] == 1
+    await repo.delete(wid)
+    assert await repo.fetch_all_workouts() == []


### PR DESCRIPTION
## Summary
- split TODO to track async repo tasks
- implement `AsyncWorkoutRepository`
- add async repo tests

## Testing
- `pytest tests/test_async_db.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c3545e4c83278b698b9a5450a3d5