### PR TITLE
Implement star rating widget

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -143,7 +143,7 @@
 [complete] 130. Quick-add notes using predefined phrases.
 131. Compare progress between two exercises.
 [complete] 132. Sort exercise library by various fields.
-133. Rate workouts using star ratings.
+[complete] 133. Rate workouts using star ratings.
 [complete] 134. Toggle to hide navigation labels.
 [complete] 135. Pin key metrics on the dashboard.
 [complete] 136. Collapsible filter panel in history tab.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,5 @@
 import datetime
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, available_timezones
 import pandas as pd
 from contextlib import contextmanager
 from pathlib import Path
@@ -2825,10 +2825,10 @@ class GymApp:
                 detail = self.workouts.fetch_detail(int(selected))
                 start_time = detail[2]
                 end_time = detail[3]
-                current_type = detail[4]
-                notes_val = detail[5] or ""
-                loc_val = detail[6] or ""
-                rating_val = detail[7]
+                current_type = detail[5]
+                notes_val = detail[6] or ""
+                loc_val = detail[7] or ""
+                rating_val = detail[8]
                 status_class = "status-idle"
                 status_label = "Idle"
                 if start_time and end_time:
@@ -2916,7 +2916,7 @@ class GymApp:
                     on_change=self._update_workout_location,
                     args=(int(selected),),
                 )
-                all_tz = sorted(ZoneInfo.available_timezones())
+                all_tz = sorted(available_timezones())
                 tz_index = all_tz.index(detail[4]) if detail[4] in all_tz else 0
                 tz_sel = st.selectbox(
                     "Timezone",
@@ -2926,10 +2926,11 @@ class GymApp:
                     on_change=self._update_workout_timezone,
                     args=(int(selected),),
                 )
-                rating_edit = st.slider(
+                stars = lambda v: "\u2605" * v + "\u2606" * (5 - v)
+                rating_edit = st.select_slider(
                     "Rating",
-                    0,
-                    5,
+                    options=[0, 1, 2, 3, 4, 5],
+                    format_func=stars,
                     value=rating_val if rating_val is not None else 0,
                     key=f"rating_{selected}",
                     on_change=self._update_workout_rating,

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -279,6 +279,22 @@ class StreamlitAppTest(unittest.TestCase):
         self.assertEqual(row, ("2024-01-02", "strength"))
         conn.close()
 
+    def test_star_rating_widget(self) -> None:
+        idx_new = _find_by_label(
+            self.at.button,
+            "New Workout",
+            key="FormSubmitter:new_workout_form-New Workout",
+        )
+        self.at.button[idx_new].click().run()
+        rating_idx = _find_by_label(self.at.select_slider, "Rating")
+        self.at.select_slider[rating_idx].set_value(3).run()
+        conn = self._connect()
+        cur = conn.cursor()
+        cur.execute("SELECT rating FROM workouts;")
+        val = cur.fetchone()[0]
+        conn.close()
+        self.assertEqual(val, 3)
+
     def test_add_favorite_exercise(self) -> None:
         self.at.query_params["tab"] = "library"
         self.at.run()


### PR DESCRIPTION
## Summary
- add star rating slider to workout details
- fix timezone list retrieval using `available_timezones`
- update TODO list
- test star rating widget

## Testing
- `pytest tests/test_streamlit_app.py::StreamlitAppTest::test_star_rating_widget -q`

------
https://chatgpt.com/codex/tasks/task_e_688a0627a0ec832799592f77dde5d18e