### PR TITLE
Implement API key management and other features

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -91,7 +91,7 @@
 79. Implement plugin architecture for custom ML models.
 [complete] 80. Add data migration script for schema changes.
 [complete] 81. Implement Slack notifications for workout logs.
-82. Add API key management for third-party integrations.
+[complete] 82. Add API key management for third-party integrations.
 [complete] 83. Provide user-friendly onboarding wizard in GUI.
 [complete] 84. Add long-term trend analytics (moving averages).
 [complete] 85. Support per-workout timezone handling.
@@ -150,10 +150,10 @@
 [complete] 137. Keyboard shortcuts help overlay.
 138. Bulk edit multiple sets at once.
 139. Randomize training plan generator.
-140. Filter exercises without equipment assigned.
+[complete] 140. Filter exercises without equipment assigned.
 [complete] 141. Switch weight units on the fly in set entry.
 142. Assign custom icons to workouts.
-143. Multi-select deletion of planned workouts.
+[complete] 143. Multi-select deletion of planned workouts.
 144. Donut charts for goal progress visualization.
 [complete] 145. Link directly to equipment details from sets.
 146. Interactive tutorial for first workout creation.
@@ -177,7 +177,7 @@
 164. Short completion animations for workouts.
 [complete] 165. Quick-add tags using hashtag syntax.
 166. Scrollable timeline of workout months.
-167. Rename logged workouts.
+[complete] 167. Rename logged workouts.
 [complete] 168. Customizable layout spacing options.
 [complete] 169. Filter by equipment type quickly.
 [complete] 170. Hide or show columns in tables.
@@ -205,7 +205,7 @@
 [complete] 192. Quick filter for unrated workouts.
 [complete] 193. Keyboard navigation in history table.
 [complete] 194. Customizable quick weight increments.
-195. Bulk mark sets as completed using checkboxes.
+[complete] 195. Bulk mark sets as completed using checkboxes.
 [complete] 196. Collapsible explanations for analytics charts.
 [complete] 197. Preview thumbnails for uploaded images.
 [complete] 198. Keyboard shortcut to toggle dark mode.

--- a/migrate.py
+++ b/migrate.py
@@ -8,6 +8,15 @@ def migrate(db_path='workout.db'):
     cols = [r[1] for r in cur.fetchall()]
     if 'thumbnail_path' not in cols:
         cur.execute("ALTER TABLE exercise_images ADD COLUMN thumbnail_path TEXT;")
+    cur.execute("PRAGMA table_info(workouts);")
+    cols = [r[1] for r in cur.fetchall()]
+    if 'name' not in cols:
+        cur.execute("ALTER TABLE workouts ADD COLUMN name TEXT;")
+    cur.execute("PRAGMA table_info(api_keys);")
+    if not cur.fetchall():
+        cur.execute(
+            "CREATE TABLE api_keys (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE, api_key TEXT NOT NULL);"
+        )
     cur.execute("PRAGMA table_info(planned_workouts);")
     cols = [r[1] for r in cur.fetchall()]
     if 'position' not in cols:

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+from fastapi.testclient import TestClient
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from rest_api import GymAPI
+
+class APIKeyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.db = "test_keys.db"
+        self.yaml = "test_keys.yaml"
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+        self.api = GymAPI(db_path=self.db, yaml_path=self.yaml)
+        self.client = TestClient(self.api.app)
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+
+    def test_api_key_crud(self):
+        resp = self.client.post("/api_keys", params={"name": "service", "key": "abc"})
+        self.assertEqual(resp.status_code, 200)
+        kid = resp.json()["id"]
+
+        resp = self.client.get("/api_keys")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), [{"id": kid, "name": "service", "key": "abc"}])
+
+        resp = self.client.delete(f"/api_keys/{kid}")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "deleted"})
+        self.assertEqual(self.client.get("/api_keys").json(), [])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_exercise_filter_no_equipment.py
+++ b/tests/test_exercise_filter_no_equipment.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+from fastapi.testclient import TestClient
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from rest_api import GymAPI
+
+class ExerciseFilterNoEquipmentTest(unittest.TestCase):
+    def setUp(self):
+        self.db = "test_filter.db"
+        self.yaml = "test_filter.yaml"
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+        self.api = GymAPI(db_path=self.db, yaml_path=self.yaml)
+        self.client = TestClient(self.api.app)
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+
+    def test_filter_no_equipment(self):
+        self.client.post(
+            "/exercise_catalog",
+            params={
+                "muscle_group": "Arms",
+                "name": "Bodyweight Curl",
+                "variants": "",
+                "equipment_names": "",
+                "primary_muscle": "Biceps Brachii",
+            },
+        )
+        resp = self.client.get("/exercise_catalog", params={"no_equipment": True})
+        self.assertIn("Bodyweight Curl", resp.json())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_planned_bulk_delete.py
+++ b/tests/test_planned_bulk_delete.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+from fastapi.testclient import TestClient
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from rest_api import GymAPI
+
+class PlannedBulkDeleteTest(unittest.TestCase):
+    def setUp(self):
+        self.db = "test_bulk.db"
+        self.yaml = "test_bulk.yaml"
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+        self.api = GymAPI(db_path=self.db, yaml_path=self.yaml)
+        self.client = TestClient(self.api.app)
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+
+    def test_delete_bulk(self):
+        ids = []
+        for _ in range(3):
+            resp = self.client.post("/planned_workouts", params={"date": "2024-01-01"})
+            ids.append(resp.json()["id"])
+        self.client.post("/planned_workouts/delete_bulk", json=",".join(str(i) for i in ids))
+        self.assertEqual(self.client.get("/planned_workouts").json(), [])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sets_bulk_complete.py
+++ b/tests/test_sets_bulk_complete.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+from fastapi.testclient import TestClient
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from rest_api import GymAPI
+
+class BulkCompleteTest(unittest.TestCase):
+    def setUp(self):
+        self.db = "test_complete.db"
+        self.yaml = "test_complete.yaml"
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+        self.api = GymAPI(db_path=self.db, yaml_path=self.yaml)
+        self.client = TestClient(self.api.app)
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+
+    def test_bulk_complete(self):
+        wid = self.client.post("/workouts").json()["id"]
+        eid = self.client.post(
+            f"/workouts/{wid}/exercises",
+            params={"name": "Bench", "equipment": "Bar"},
+        ).json()["id"]
+        ids = []
+        for _ in range(2):
+            r = self.client.post(f"/exercises/{eid}/sets", params={"reps": 5, "weight": 50.0, "rpe": 8})
+            ids.append(r.json()["id"])
+        self.client.post("/sets/bulk_complete", params={"set_ids": ",".join(str(i) for i in ids)})
+        data = self.client.get(f"/exercises/{eid}/sets").json()
+        for entry in data:
+            self.assertIn("end_time", entry)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workout_rename.py
+++ b/tests/test_workout_rename.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+from fastapi.testclient import TestClient
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from rest_api import GymAPI
+
+class WorkoutRenameTest(unittest.TestCase):
+    def setUp(self):
+        self.db = "test_rename.db"
+        self.yaml = "test_rename.yaml"
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+        self.api = GymAPI(db_path=self.db, yaml_path=self.yaml)
+        self.client = TestClient(self.api.app)
+
+    def tearDown(self):
+        if os.path.exists(self.db):
+            os.remove(self.db)
+        if os.path.exists(self.yaml):
+            os.remove(self.yaml)
+
+    def test_rename_workout(self):
+        wid = self.client.post("/workouts").json()["id"]
+        resp = self.client.put(f"/workouts/{wid}/name", params={"name": "Test"})
+        self.assertEqual(resp.status_code, 200)
+        data = self.client.get(f"/workouts/{wid}").json()
+        self.assertEqual(data["name"], "Test")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add workout `name` column and migration
- add APIKeyRepository and endpoints
- implement bulk delete for planned workouts
- allow filtering exercises with no equipment
- add bulk set completion
- expose workout name in detail endpoint
- add comprehensive tests
- mark completed TODO items

## Testing
- `pytest tests/test_api.py::APITestCase::test_full_workflow -q`
- `pytest tests/test_api_keys.py -q`
- `pytest tests/test_workout_rename.py -q`
- `pytest tests/test_planned_bulk_delete.py -q`
- `pytest tests/test_exercise_filter_no_equipment.py -q`
- `pytest tests/test_sets_bulk_complete.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688a6bd992f88327a98638197d2bd158