### PR TITLE
Add DB_URL support and fix workout creation call

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,2 +1,3 @@
 test_tooltips_present and test_workout_search failed during run
 API tests failed: calendar_endpoint, copy_workout_to_template, duplicate_workout, general_settings, plan_progress, plan_workflow, schema_migration, training_type_summary_endpoint, workout_history_endpoint
+test_ml_service failed: test_performance_model_train_predict

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following variables control runtime paths:
 | Variable  | Description                      | Default        |
 |-----------|----------------------------------|----------------|
 | `DB_PATH` | Path to the SQLite database file | `workout.db`   |
+| `DB_URL`  | Optional PostgreSQL connection URL | *(unset)* |
 | `YAML_PATH` | Path to the settings YAML       | `settings.yaml`|
 | `TEST_MODE` | Enable simplified test behaviour | `0` |
 

--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,7 @@
 [complete] 39. Add coverage reporting to tests.
 [complete] 40. Document environment variables for deployment in README.
 41. Add support for external database like PostgreSQL.
+41a. Add DB_URL env variable for external database configuration. [complete]
 [complete] 42. Add repository pattern for ml_service states.
 [complete] 43. Add progress bar to Streamlit when uploading CSV files.
 [complete] 44. Provide data validation on CSV imports.

--- a/db.py
+++ b/db.py
@@ -562,7 +562,8 @@ class Database:
         ),
     }
 
-    def __init__(self, db_path: str = "workout.db") -> None:
+    def __init__(self, db_path: str = "workout.db", db_url: str | None = None) -> None:
+        self._db_url = db_url or os.environ.get("DB_URL")
         self._db_path = db_path
         self._ensure_schema()
         self._import_equipment_data()
@@ -574,8 +575,12 @@ class Database:
         self.vacuum()
 
     @contextmanager
-    def _connection(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self._db_path)
+    def _connection(self):
+        if self._db_url and self._db_url.startswith("postgresql"):
+            import psycopg2
+            connection = psycopg2.connect(self._db_url)
+        else:
+            connection = sqlite3.connect(self._db_path)
         try:
             yield connection
             connection.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ pyttsx3
 Pillow>=9.0.0
 matplotlib
 keyring
+psycopg2-binary
+asyncpg

--- a/rest_api.py
+++ b/rest_api.py
@@ -968,18 +968,17 @@ class GymAPI:
                 )
             workout_id = await self.async_workouts.create(
                 workout_date.isoformat(),
-                None,
-                timezone,
-                training_type,
-                notes,
-                location,
+                timezone=timezone,
+                training_type=training_type,
+                notes=notes,
+                location=location,
                 rating=rating,
                 mood_before=mood_before,
                 mood_after=mood_after,
-                icon=icon,
                 start_time=start_time,
                 end_time=end_time,
             )
+            await self.async_workouts.set_icon(workout_id, icon)
             if notes:
                 tags = re.findall(r"#(\w+)", notes)
                 for t in tags:


### PR DESCRIPTION
## Summary
- implement DB_URL optional environment variable
- document new DB_URL setting
- fix async workout creation call to avoid duplicate rating argument
- log failing ml_service test

## Testing
- `pytest tests/test_async_db.py`
- `pytest tests/test_api.py::APITestCase::test_add_warmup_sets -q`
- `pytest tests/test_api.py::APITestCase::test_power_history_endpoint -q`
- `pytest tests/test_cli_tools.py -q`
- `pytest tests/test_tools.py -q`
- `PYTHONPATH=. pytest tests/test_ml_service.py -q` *(fails: ModuleNotFoundError or assertion)*

------
https://chatgpt.com/codex/tasks/task_e_688ba1906f00832781f32d2f05aaec0a