### PR TITLE
Implement step counter integration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -173,7 +173,7 @@
 [complete] 155. Toggle display of estimated 1RM.
 [complete] 156. Indicator for unsaved changes in forms.
 [complete] 157. Collapsible summary metrics in history.
-158. Step counter integration for cardio.
+[complete] 158. Step counter integration for cardio.
 [complete] 159. Quick access to recently used templates.
 [complete] 160. Mini progress widget on home screen.
 [complete] 161. Filter results by muscle group across tabs.

--- a/migrate.py
+++ b/migrate.py
@@ -29,6 +29,11 @@ def migrate(db_path='workout.db'):
     cols = [r[1] for r in cur.fetchall()]
     if 'last_used' not in cols:
         cur.execute("ALTER TABLE workout_templates ADD COLUMN last_used TEXT;")
+    cur.execute("PRAGMA table_info(step_count_logs);")
+    if not cur.fetchall():
+        cur.execute(
+            "CREATE TABLE step_count_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, workout_id INTEGER NOT NULL, timestamp TEXT NOT NULL, steps INTEGER NOT NULL, FOREIGN KEY(workout_id) REFERENCES workouts(id) ON DELETE CASCADE);"
+        )
     conn.commit()
     conn.close()
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -47,6 +47,7 @@ from db import (
     BodyWeightRepository,
     WellnessRepository,
     HeartRateRepository,
+    StepCountRepository,
     FavoriteExerciseRepository,
     FavoriteTemplateRepository,
     FavoriteWorkoutRepository,
@@ -300,6 +301,7 @@ class GymApp:
         self.body_weights_repo = BodyWeightRepository(db_path)
         self.wellness_repo = WellnessRepository(db_path)
         self.heart_rates = HeartRateRepository(db_path)
+        self.step_counts = StepCountRepository(db_path)
         self.stats_cache_repo = StatsCacheRepository(db_path)
         self.gamification = GamificationService(
             self.game_repo,
@@ -367,6 +369,8 @@ class GymApp:
             self.exercise_catalog,
             self.workouts,
             self.heart_rates,
+            self.step_counts,
+            self.goals_repo,
             cache_repo=self.stats_cache_repo,
         )
         self._state_init()


### PR DESCRIPTION
## Summary
- integrate step counter logging via new `step_count_logs` table
- provide StepCountRepository and REST API endpoints
- expose step summary analytics
- hook step counts into stats service and Streamlit app
- create migration logic for the new table
- test API step count operations
- mark TODO item as complete

## Testing
- `pytest tests/test_api.py::APITestCase::test_step_logging -q`
- `pytest tests/test_api.py::APITestCase::test_step_summary -q`
- `pytest tests/test_api.py -q`
- `pytest tests/test_streamlit_app.py -k mobile_bottom_nav -q`
- `pytest tests/test_mobile_layout.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688c6d70e2508327b9ca5c052d5f16a8