### PR TITLE
Add async reaction repository

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,12 +27,12 @@
 20b1. Convert WorkoutRepository to AsyncWorkoutRepository. [complete]
 20b2a. Convert TagRepository to AsyncTagRepository. [complete]
 20b2b. Convert ExerciseRepository to AsyncExerciseRepository. [complete]
-20b2. Convert remaining repositories to async versions.
+20b2. Convert remaining repositories to async versions. [partial]
 20c1. Update REST API workouts endpoints to async. [complete]
-20c2. Update remaining endpoints to async.
+20c2. Update remaining endpoints to async. [partial]
 20d1. Add tests for AsyncWorkoutRepository. [complete]
 20d2a. Add tests for AsyncExerciseRepository. [complete]
-20d2. Update remaining tests for async operations.
+20d2. Update remaining tests for async operations. [partial]
 20d2b. Fix failing StreamlitAppTest cases after async refactor.
 [complete] 21. Add unit tests for ml_service models.
 [complete] 22. Provide interactive charts for power and velocity histories.

--- a/rest_api.py
+++ b/rest_api.py
@@ -62,7 +62,7 @@ from db import (
     FavoriteTemplateRepository,
     FavoriteWorkoutRepository,
     DefaultEquipmentRepository,
-    ReactionRepository,
+    AsyncReactionRepository,
     TagRepository,
     AsyncTagRepository,
     APIKeyRepository,
@@ -195,7 +195,7 @@ class GymAPI:
         self.favorite_templates = FavoriteTemplateRepository(db_path)
         self.favorite_workouts = FavoriteWorkoutRepository(db_path)
         self.default_equipment = DefaultEquipmentRepository(db_path, self.exercise_names)
-        self.reactions = ReactionRepository(db_path)
+        self.reactions = AsyncReactionRepository(db_path)
         self.tags = TagRepository(db_path)
         self.async_tags = AsyncTagRepository(db_path)
         self.pyramid_tests = PyramidTestRepository(db_path)
@@ -1201,13 +1201,13 @@ class GymAPI:
             return {"calories": cal}
 
         @self.app.post("/workouts/{workout_id}/reactions")
-        def add_reaction(workout_id: int, emoji: str = Body(...)):
-            self.reactions.react(workout_id, emoji)
+        async def add_reaction(workout_id: int, emoji: str = Body(...)):
+            await self.reactions.react(workout_id, emoji)
             return {"status": "recorded"}
 
         @self.app.get("/workouts/{workout_id}/reactions")
-        def list_reactions(workout_id: int):
-            data = self.reactions.list_for_workout(workout_id)
+        async def list_reactions(workout_id: int):
+            data = await self.reactions.list_for_workout(workout_id)
             return [{"emoji": e, "count": c} for e, c in data]
 
         @self.app.post("/workouts/{workout_id}/comments")

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -9,6 +9,7 @@ from db import (
     AsyncWorkoutRepository,
     AsyncTagRepository,
     AsyncExerciseRepository,
+    AsyncReactionRepository,
 )
 
 class NumberRepository(AsyncBaseRepository):
@@ -68,4 +69,15 @@ async def test_async_exercise_repo(tmp_path):
     assert detail[1] == "Bench Press"
     await ex_repo.remove(ex_id)
     assert await ex_repo.fetch_for_workout(wid) == []
+
+
+@pytest.mark.asyncio
+async def test_async_reaction_repo(tmp_path):
+    db_file = str(tmp_path / "react.db")
+    workout_repo = AsyncWorkoutRepository(db_file)
+    wid = await workout_repo.create("2024-01-03")
+    repo = AsyncReactionRepository(db_file)
+    await repo.react(wid, "👍")
+    rows = await repo.list_for_workout(wid)
+    assert rows == [("👍", 1)]
 


### PR DESCRIPTION
## Summary
- convert workout reactions to async repository
- update reaction endpoints to async
- cover new async repository with tests
- note progress on TODO

## Testing
- `pytest tests/test_async_db.py::test_async_repository -q`
- `pytest tests/test_async_db.py::test_async_workout_repo -q`
- `pytest tests/test_async_db.py::test_async_tag_repo -q`
- `pytest tests/test_async_db.py::test_async_exercise_repo -q`
- `pytest tests/test_async_db.py::test_async_reaction_repo -q`
- `pytest tests/test_api.py::APITestCase::test_workout_reactions -q`


------
https://chatgpt.com/codex/tasks/task_e_688c7b0911248327b436d4b1d7f15ec8