### PR TITLE
Implement async body weight repo

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,13 +27,13 @@
 20b1. Convert WorkoutRepository to AsyncWorkoutRepository. [complete]
 20b2a. Convert TagRepository to AsyncTagRepository. [complete]
 20b2b. Convert ExerciseRepository to AsyncExerciseRepository. [complete]
-20b2. Convert remaining repositories to async versions. [partial]
+20b2. Convert remaining repositories to async versions. [partial - BodyWeightRepository converted]
 20c1. Update REST API workouts endpoints to async. [complete]
 20c2. Update remaining endpoints to async. [partial]
 20d1. Add tests for AsyncWorkoutRepository. [complete]
 20d2a. Add tests for AsyncExerciseRepository. [complete]
 20d2. Update remaining tests for async operations. [partial]
-20d2b. Fix failing StreamlitAppTest cases after async refactor.
+20d2b. Fix failing StreamlitAppTest cases after async refactor. [complete]
 [complete] 21. Add unit tests for ml_service models.
 [complete] 22. Provide interactive charts for power and velocity histories.
 [complete] 23. Add endpoint for exercise alias removal.

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -10,6 +10,7 @@ from db import (
     AsyncTagRepository,
     AsyncExerciseRepository,
     AsyncReactionRepository,
+    AsyncBodyWeightRepository,
 )
 
 class NumberRepository(AsyncBaseRepository):
@@ -80,4 +81,19 @@ async def test_async_reaction_repo(tmp_path):
     await repo.react(wid, "👍")
     rows = await repo.list_for_workout(wid)
     assert rows == [("👍", 1)]
+
+
+@pytest.mark.asyncio
+async def test_async_body_weight_repo(tmp_path):
+    db_file = str(tmp_path / "bw.db")
+    repo = AsyncBodyWeightRepository(db_file)
+    eid = await repo.log("2024-01-01", 80.5)
+    rows = await repo.fetch_history()
+    assert rows == [(eid, "2024-01-01", 80.5)]
+    await repo.update(eid, "2024-01-02", 82.0)
+    rows = await repo.fetch_history("2024-01-02", "2024-01-02")
+    assert rows[0][2] == 82.0
+    assert rows[0][1] == "2024-01-02"
+    await repo.delete(eid)
+    assert await repo.fetch_history() == []
 


### PR DESCRIPTION
## Summary
- implement `AsyncBodyWeightRepository`
- instantiate async repo in `GymAPI`
- convert `/body_weight` endpoints to async
- test async repo functionality
- update TODO progress

## Testing
- `pytest -q tests/test_async_db.py`
- `pytest tests/test_api.py::APITestCase::test_body_weight_logging_and_stats -q`
- `pytest tests/test_api.py::APITestCase::test_body_weight_update_and_delete -q`
- `pytest tests/test_api.py::APITestCase::test_body_weight_csv_export -q`
- `pytest tests/test_api.py::APITestCase::test_current_body_weight_latest_log -q`
- `pytest tests/test_api.py::APITestCase::test_recommender_body_weight_latest_log -q`


------
https://chatgpt.com/codex/tasks/task_e_688c953bc6e08327babdcf4281e2e474