### PR TITLE
Implement async notifications

### DIFF
--- a/FAILEDTESTS.md
+++ b/FAILEDTESTS.md
@@ -1,1 +1,5 @@
-No failing tests.
+Failed tests after AsyncNotificationRepository changes:
+- tests/test_streamlit_app.py::StreamlitAppTest::test_tooltips_present
+- tests/test_streamlit_app.py::StreamlitAppTest::test_workout_search
+- tests/test_streamlit_app.py::StreamlitFullGUITest::test_goal_donut_chart
+- tests/test_streamlit_app.py::StreamlitTemplateWorkflowTest::test_template_plan_to_workout

--- a/TODO.md
+++ b/TODO.md
@@ -27,12 +27,12 @@
 20b1. Convert WorkoutRepository to AsyncWorkoutRepository. [complete]
 20b2a. Convert TagRepository to AsyncTagRepository. [complete]
 20b2b. Convert ExerciseRepository to AsyncExerciseRepository. [complete]
-20b2. Convert remaining repositories to async versions. [partial - BodyWeightRepository converted]
+20b2. Convert remaining repositories to async versions. [partial - BodyWeightRepository, NotificationRepository converted]
 20c1. Update REST API workouts endpoints to async. [complete]
-20c2. Update remaining endpoints to async. [partial]
+20c2. Update remaining endpoints to async. [partial - notification endpoints converted]
 20d1. Add tests for AsyncWorkoutRepository. [complete]
 20d2a. Add tests for AsyncExerciseRepository. [complete]
-20d2. Update remaining tests for async operations. [partial]
+20d2. Update remaining tests for async operations. [partial - notification tests added]
 20d2b. Fix failing StreamlitAppTest cases after async refactor. [complete]
 [complete] 21. Add unit tests for ml_service models.
 [complete] 22. Provide interactive charts for power and velocity histories.

--- a/rest_api.py
+++ b/rest_api.py
@@ -48,6 +48,7 @@ from db import (
     MLLogRepository,
     MLModelStatusRepository,
     NotificationRepository,
+    AsyncNotificationRepository,
     WorkoutCommentRepository,
     MLTrainingRawRepository,
     AutoPlannerLogRepository,
@@ -206,6 +207,7 @@ class GymAPI:
         self.ml_logs = MLLogRepository(db_path)
         self.ml_status = MLModelStatusRepository(db_path)
         self.notifications = NotificationRepository(db_path)
+        self.async_notifications = AsyncNotificationRepository(db_path)
         self.comments = WorkoutCommentRepository(db_path)
         self.api_keys = APIKeyRepository(db_path)
         self.ml_training_raw = MLTrainingRawRepository(db_path)
@@ -3372,22 +3374,23 @@ class GymAPI:
             return Response(content=data, media_type="application/pdf")
 
         @self.app.post("/notifications")
-        def create_notification(message: str = Body(...)):
-            nid = self.notifications.add(message)
+        async def create_notification(message: str = Body(...)):
+            nid = await self.async_notifications.add(message)
             return {"id": nid}
 
         @self.app.get("/notifications")
-        def get_notifications(unread_only: bool = False):
-            return self.notifications.fetch_all(unread_only)
+        async def get_notifications(unread_only: bool = False):
+            return await self.async_notifications.fetch_all(unread_only)
 
         @self.app.put("/notifications/{nid}/read")
-        def mark_notification_read(nid: int):
-            self.notifications.mark_read(nid)
+        async def mark_notification_read(nid: int):
+            await self.async_notifications.mark_read(nid)
             return {"status": "read"}
 
         @self.app.get("/notifications/unread_count")
-        def unread_count():
-            return {"count": self.notifications.unread_count()}
+        async def unread_count():
+            count = await self.async_notifications.unread_count()
+            return {"count": count}
 
         @self.app.get("/api_keys")
         def list_api_keys():

--- a/tests/test_async_db.py
+++ b/tests/test_async_db.py
@@ -11,6 +11,7 @@ from db import (
     AsyncExerciseRepository,
     AsyncReactionRepository,
     AsyncBodyWeightRepository,
+    AsyncNotificationRepository,
 )
 
 class NumberRepository(AsyncBaseRepository):
@@ -96,4 +97,20 @@ async def test_async_body_weight_repo(tmp_path):
     assert rows[0][1] == "2024-01-02"
     await repo.delete(eid)
     assert await repo.fetch_history() == []
+
+
+@pytest.mark.asyncio
+async def test_async_notification_repo(tmp_path):
+    db_file = str(tmp_path / "notif.db")
+    repo = AsyncNotificationRepository(db_file)
+    nid = await repo.add("hello")
+    notes = await repo.fetch_all()
+    assert notes[0]["id"] == nid
+    assert notes[0]["message"] == "hello"
+    assert notes[0]["read"] is False
+    await repo.mark_read(nid)
+    notes = await repo.fetch_all()
+    assert notes[0]["read"] is True
+    count = await repo.unread_count()
+    assert count == 0
 


### PR DESCRIPTION
## Summary
- add AsyncNotificationRepository
- enable async notification endpoints
- initialize async notifications in API
- test async notifications
- document failing GUI tests
- update TODO progress

## Testing
- `pytest tests/test_async_db.py -q`
- `pytest tests/test_api.py -q`
- `pytest tests/test_streamlit_app.py -q` *(fails: test_tooltips_present, test_workout_search, test_goal_donut_chart, test_template_plan_to_workout)*

------
https://chatgpt.com/codex/tasks/task_e_688c9ae551748327921736afd65bcd7f