### PR TITLE
Replace history expanders with tabs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -229,7 +229,7 @@
 [complete] 200. "Clear filters" button in history tab.
 [complete] 201. Remove all multiuser features from the code base.
 
-202. Replace expander sections in History tab with nested tabs. [pending]
+202. Replace expander sections in History tab with nested tabs. [complete]
 203. Convert Progress tab expanders to subtabs for metrics and charts. [pending]
 204. Use subtabs in Planner tab instead of expanders for goal planner and templates. [pending]
 205. Replace settings expanders with subtab sections. [pending]

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1082,14 +1082,15 @@ class StreamlitFullGUITest(unittest.TestCase):
     def test_history_tab(self) -> None:
         tab = self._get_tab("History")
         self.assertEqual(tab.header[0].value, "Workout History")
-        self.assertGreater(len(tab.expander), 1)
-        filt_exp = tab.expander[1]
-        buttons = [b.label for b in filt_exp.button]
+        labels = [t.label for t in tab.tabs]
+        self.assertIn("List", labels)
+        list_tab = next(t for t in tab.tabs if t.label == "List")
+        buttons = [b.label for b in list_tab.button]
         self.assertIn("Last 7d", buttons)
         self.assertIn("Last 30d", buttons)
         self.assertIn("Last 90d", buttons)
         self.assertIn("Clear Filters", buttons)
-        chk_labels = [c.label for c in filt_exp.checkbox]
+        chk_labels = [c.label for c in list_tab.checkbox]
         self.assertIn("Unrated Only", chk_labels)
 
     def test_dashboard_tab(self) -> None:


### PR DESCRIPTION
## Summary
- convert History tab to use nested tabs instead of expanders
- adjust Workout Details dialog to display exercises in tabs
- update GUI tests for new tab structure
- mark TODO step 202 complete

## Testing
- `pytest -q tests/test_streamlit_app.py`
- `pytest -q tests/test_mobile_layout.py`
- `pytest -q tests/test_mobile_css.py`
- `pytest -q tests/test_onboarding_help.py`


------
https://chatgpt.com/codex/tasks/task_e_688cfd77815083278b38fd19a8ff764b