### PR TITLE
Refactor initial GUI sections to tabs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -230,10 +230,10 @@
 [complete] 201. Remove all multiuser features from the code base.
 
 202. Replace expander sections in History tab with nested tabs. [complete]
-203. Convert Progress tab expanders to subtabs for metrics and charts. [pending]
+203. Convert Progress tab expanders to subtabs for metrics and charts. [partial]
 204. Use subtabs in Planner tab instead of expanders for goal planner and templates. [pending]
 205. Replace settings expanders with subtab sections. [pending]
 206. Update JS persistence logic for tabs and remove expander code. [pending]
-207. Remove references to self.at.expander in GUI tests and add tab checks. [pending]
+207. Remove references to self.at.expander in GUI tests and add tab checks. [partial]
 208. Adjust responsive CSS for nested tabs and subtabs. [pending]
 209. Fully remove all Streamlit expander usage across the application. [pending]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5957,7 +5957,26 @@ class GymApp:
 
     def _weight_tab(self) -> None:
         st.header("Body Weight")
-        with st.expander("Date Range", expanded=True):
+        (
+            range_tab,
+            stats_tab,
+            weight_hist_tab,
+            bmi_tab,
+            well_sum_tab,
+            well_hist_tab,
+            forecast_tab,
+        ) = st.tabs(
+            [
+                "Date Range",
+                "Statistics",
+                "Weight History",
+                "BMI History",
+                "Wellness Summary",
+                "Wellness History",
+                "Forecast",
+            ]
+        )
+        with range_tab:
             col1, col2 = st.columns(2)
             with col1:
                 start = st.date_input(
@@ -5976,7 +5995,7 @@ class GymApp:
             start_str = start.isoformat()
             end_str = end.isoformat()
         stats = self.stats.weight_stats(start_str, end_str, unit=self.weight_unit)
-        with st.expander("Statistics", expanded=True):
+        with stats_tab:
             metrics = [
                 ("Average", stats["avg"]),
                 ("Min", stats["min"]),
@@ -5985,20 +6004,20 @@ class GymApp:
             self._metric_grid(metrics)
         history = self.stats.body_weight_history(start_str, end_str)
         if history:
-            with st.expander("Weight History", expanded=True):
+            with weight_hist_tab:
                 self._line_chart(
                     {"Weight": [h["weight"] for h in history]},
                     [h["date"] for h in history],
                 )
         bmi_hist = self.stats.bmi_history(start_str, end_str)
         if bmi_hist:
-            with st.expander("BMI History", expanded=False):
+            with bmi_tab:
                 self._line_chart(
                     {"BMI": [b["bmi"] for b in bmi_hist]},
                     [b["date"] for b in bmi_hist],
                 )
         wellness = self.stats.wellness_summary(start_str, end_str)
-        with st.expander("Wellness Summary", expanded=False):
+        with well_sum_tab:
             metrics = [
                 ("Calories", wellness["avg_calories"]),
                 ("Sleep Hours", wellness["avg_sleep"]),
@@ -6008,7 +6027,7 @@ class GymApp:
             self._metric_grid(metrics)
         well_hist = self.stats.wellness_history(start_str, end_str)
         if well_hist:
-            with st.expander("Wellness History", expanded=False):
+            with well_hist_tab:
                 self._line_chart(
                     {
                         "Calories": [w["calories"] for w in well_hist],
@@ -6018,7 +6037,7 @@ class GymApp:
                     },
                     [w["date"] for w in well_hist],
                 )
-        with st.expander("Forecast", expanded=False):
+        with forecast_tab:
             days = st.slider("Days", 1, 14, 7, key="bw_fc_days")
             if st.button("Show Forecast", key="bw_fc_btn"):
                 forecast = self.stats.weight_forecast(days)
@@ -6030,7 +6049,8 @@ class GymApp:
 
     def _wellness_tab(self) -> None:
         st.header("Wellness Logs")
-        with st.expander("Add Entry"):
+        entry_tab, history_tab = st.tabs(["Add Entry", "History"])
+        with entry_tab:
             w_date = st.date_input(
                 "Date",
                 datetime.date.today(),
@@ -6065,7 +6085,7 @@ class GymApp:
                 except ValueError as e:
                     st.warning(str(e))
 
-        with st.expander("History", expanded=True):
+        with history_tab:
             rows = self.wellness_repo.fetch_history()
             for rid, d, cal, sh, sq, st_lvl in rows:
                 exp = st.expander(f"{d}")

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1140,12 +1140,13 @@ class StreamlitFullGUITest(unittest.TestCase):
     def test_wellness_tab(self) -> None:
         tab = self._get_tab("Wellness Logs")
         self.assertEqual(tab.header[0].value, "Wellness Logs")
-        tab.expander[0].date_input[0].set_value("2024-01-03").run()
-        tab.expander[0].number_input[0].set_value(2500.0).run()
-        tab.expander[0].number_input[1].set_value(8.0).run()
-        tab.expander[0].number_input[2].set_value(5.0).run()
-        tab.expander[0].number_input[3].set_value(3).run()
-        tab.expander[0].button[0].click().run()
+        entry_tab = tab.tabs[0]
+        entry_tab.date_input[0].set_value("2024-01-03").run()
+        entry_tab.number_input[0].set_value(2500.0).run()
+        entry_tab.number_input[1].set_value(8.0).run()
+        entry_tab.number_input[2].set_value(5.0).run()
+        entry_tab.number_input[3].set_value(3).run()
+        entry_tab.button[0].click().run()
         conn = self._connect()
         cur = conn.cursor()
         cur.execute(


### PR DESCRIPTION
## Summary
- start converting expanders to tabs in the Progress area
- modify wellness logging to use sub‑tabs
- update GUI tests for new tab structure
- mark TODO steps for progress refactor as partial

## Testing
- `pytest tests/test_streamlit_app.py -k test_weight_tab -q`
- `pytest tests/test_streamlit_app.py -k test_wellness_tab -q`


------
https://chatgpt.com/codex/tasks/task_e_688d19d480c8832791d0e2f68ba1d4f8