### PR TITLE
Handle leftover backup tables during schema migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,3 +528,4 @@ keep the AGENTS.md updated by adding new sensible rules when they occur to you. 
 - Multiuser features are prohibited. The application must remain single-user and any existing multiuser functionality should be removed.
 - The "Jump to Section" dropdown has been removed from the UI and must not be reintroduced.
 - When replacing expanders with tabs, corresponding GUI tests must be updated to verify tab behavior.
+- Schema migrations must drop any leftover tables suffixed with `_old` before renaming to avoid conflicts.

--- a/db.py
+++ b/db.py
@@ -645,6 +645,7 @@ class Database:
         if existing_cols == columns:
             return
 
+        conn.execute(f"DROP TABLE IF EXISTS {table}_old;")
         conn.execute(f"ALTER TABLE {table} RENAME TO {table}_old;")
         conn.execute(sql)
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1,0 +1,30 @@
+import os
+import sqlite3
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from db import Database
+
+
+class TestSchemaMigration:
+    def test_drops_existing_backup_table(self, tmp_path):
+        db_file = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_file))
+        conn.execute(
+            "CREATE TABLE sets (id INTEGER PRIMARY KEY AUTOINCREMENT, exercise_id INTEGER, reps INTEGER, weight REAL, rpe INTEGER)"
+        )
+        conn.execute("CREATE TABLE sets_old (id INTEGER)")
+        conn.commit()
+        conn.close()
+
+        Database(str(db_file))
+
+        conn = sqlite3.connect(str(db_file))
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='sets_old'"
+        )
+        assert cur.fetchone() is None
+        cur = conn.execute("PRAGMA table_info(sets)")
+        cols = [row[1] for row in cur.fetchall()]
+        assert "diff_reps" in cols
+        conn.close()


### PR DESCRIPTION
## Summary
- Drop any existing `_old` table before renaming during schema migrations to avoid OperationalError.
- Document guideline about cleaning up `_old` tables in AGENTS instructions.
- Add regression test covering migrations with pre-existing backup tables.

## Testing
- `pytest tests/test_schema_migration.py -q`
- `pytest tests/test_async_db.py -q`
- `pytest tests/test_async_set_repo.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0f54793483279a0cfb73879abdb4