### PR TITLE
fix: mark javascript block as raw string

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -609,7 +609,7 @@ class GymApp:
         st.session_state.is_tablet = mode == "tablet"
         components.html(
             (
-                """
+                r"""
             <script>
             function setMode() {
                 const w = Math.min(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Summary
- mark Streamlit app JavaScript snippet as raw string to prevent invalid escape warnings

## Testing
- `pytest tests/test_streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_688f14db22e48327a900e7e027daecf4